### PR TITLE
Basic Error Recovery

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -595,10 +595,11 @@ cast <nombre de la función>
   <expresion 2>,
   ...
   <expresion n>
+  to the estus flask
 ]
 ```
 
-Donde cada _expresion i_ corresponde a un argumento a pasar a la función, que debe corresponder con el tipo declarado. Si la función no recibe parámetros, el bloque que inicia con _granting_ no es requerido.
+Donde cada _expresion i_ corresponde a un argumento a pasar a la función, que debe corresponder con el tipo declarado. Si la función no recibe parámetros, el bloque que inicia con _offering_ no es requerido.
 
 La llamada a la función NO evalúa a ninguna expresión.
 

--- a/samples/error_recovery/alias_list_end.souls
+++ b/samples/error_recovery/alias_list_end.souls
@@ -1,0 +1,10 @@
+hello ashen one
+
+requiring help of
+    knight onion humanity
+
+traveling somewhere
+    with orange saponite say @Hello, ashen one!@
+you died
+
+farewell ashen one

--- a/samples/error_recovery/closing_brace.souls
+++ b/samples/error_recovery/closing_brace.souls
@@ -1,0 +1,13 @@
+hello ashen one
+
+requiring help of
+    knight onion bezel {
+        test of type humanity,
+        test2 of type hollow
+help received
+
+traveling somewhere
+    with orange saponite say @Hello, ashen one!@
+you died
+
+farewell ashen one

--- a/samples/error_recovery/declaration_list_end.souls
+++ b/samples/error_recovery/declaration_list_end.souls
@@ -1,0 +1,9 @@
+hello ashen one
+
+traveling somewhere
+with
+    var n of type humanity
+    with orange saponite say @Hello, ashen one!@
+you died
+
+farewell ashen one

--- a/samples/error_recovery/function_call_end.souls
+++ b/samples/error_recovery/function_call_end.souls
@@ -1,0 +1,20 @@
+hello ashen one
+
+invocation s
+requesting
+    val a of type humanity
+with skill of type humanity
+    traveling somewhere
+        go back with a + 1
+    you died
+after this return to your world
+
+traveling somewhere
+with
+    var a of type humanity
+in your inventory
+    a <<= summon s
+        granting 1
+you died
+
+farewell ashen one

--- a/samples/error_recovery/instruction_list_end.souls
+++ b/samples/error_recovery/instruction_list_end.souls
@@ -1,0 +1,6 @@
+hello ashen one
+
+traveling somewhere
+    with orange saponite say @Hello, ashen one!@
+
+farewell ashen one

--- a/samples/error_recovery/procedure_call_end.souls
+++ b/samples/error_recovery/procedure_call_end.souls
@@ -1,0 +1,21 @@
+hello ashen one
+
+spell s
+requesting
+    val a of type humanity
+to the estus flask
+    traveling somewhere
+        go back
+    you died
+ashen estus flask consumed
+
+traveling somewhere
+with
+    var a of type humanity
+in your inventory
+    cast s
+        offering 1
+        to the estus flask
+you died
+
+farewell ashen one

--- a/samples/error_recovery/program_end.souls
+++ b/samples/error_recovery/program_end.souls
@@ -1,0 +1,5 @@
+hello ashen one
+
+traveling somewhere
+    with orange saponite say @Hello, ashen one!@
+you died

--- a/src/Grammar.hs
+++ b/src/Grammar.hs
@@ -3,6 +3,7 @@ module Grammar where
 import Lexer (Token)
 import TypeChecking (Type(..))
 import Data.List (intercalate)
+import qualified Utils as U
 
 type Instructions = [Instruction]
 type Params = [Expr]
@@ -147,3 +148,11 @@ data GrammarType
   | Record Token [(Id, GrammarType)]
   | Callable (Maybe GrammarType) [(ArgType, Id, GrammarType)]
   deriving Show
+
+data RecoverableError
+  = MissingProgramEnd
+  | MissingInstructionEnd
+
+instance Show RecoverableError where
+  show MissingProgramEnd = "Unclosed program block: forgot to say " ++ U.bold ++ "farewell ashen one" ++ U.nocolor
+  show MissingInstructionEnd = "Unclosed instruction block: remember that " ++ U.bold ++ "you died" ++ U.nocolor

--- a/src/Grammar.hs
+++ b/src/Grammar.hs
@@ -151,12 +151,14 @@ data GrammarType
 
 data RecoverableError
   = MissingProgramEnd
+  | MissingDeclarationListEnd
   | MissingInstructionListEnd
   | MissingAliasListEnd
   | MissingClosingBrace
 
 instance Show RecoverableError where
   show MissingProgramEnd = "Unclosed program block: forgot to say " ++ U.bold ++ "farewell ashen one" ++ U.nocolor
+  show MissingDeclarationListEnd = "Unclosed declaration block: you need to state what's " ++ U.bold ++ "in your inventory" ++ U.nocolor
   show MissingInstructionListEnd = "Unclosed instruction block: remember that " ++ U.bold ++ "you died" ++ U.nocolor
   show MissingAliasListEnd = "Unclosed alias list: be thankful of the " ++ U.bold ++ "help received" ++ U.nocolor
   show MissingClosingBrace = "Unclosed brace: mismatched { without its closing " ++ U.bold ++ "}" ++ U.nocolor

--- a/src/Grammar.hs
+++ b/src/Grammar.hs
@@ -155,6 +155,8 @@ data RecoverableError
   | MissingInstructionListEnd
   | MissingAliasListEnd
   | MissingClosingBrace
+  | MissingFunCallEnd
+  | MissingProcCallEnd
 
 instance Show RecoverableError where
   show MissingProgramEnd = "Unclosed program block: forgot to say " ++ U.bold ++ "farewell ashen one" ++ U.nocolor
@@ -162,3 +164,5 @@ instance Show RecoverableError where
   show MissingInstructionListEnd = "Unclosed instruction block: remember that " ++ U.bold ++ "you died" ++ U.nocolor
   show MissingAliasListEnd = "Unclosed alias list: be thankful of the " ++ U.bold ++ "help received" ++ U.nocolor
   show MissingClosingBrace = "Unclosed brace: mismatched { without its closing " ++ U.bold ++ "}" ++ U.nocolor
+  show MissingFunCallEnd = "Unclosed function call: state your grants " ++ U.bold ++ "to the knight" ++ U.nocolor
+  show MissingProcCallEnd = "Unclosed procedure call: state your requests " ++ U.bold ++ "to the estus flask" ++ U.nocolor

--- a/src/Grammar.hs
+++ b/src/Grammar.hs
@@ -153,8 +153,10 @@ data RecoverableError
   = MissingProgramEnd
   | MissingInstructionListEnd
   | MissingAliasListEnd
+  | MissingClosingBrace
 
 instance Show RecoverableError where
   show MissingProgramEnd = "Unclosed program block: forgot to say " ++ U.bold ++ "farewell ashen one" ++ U.nocolor
   show MissingInstructionListEnd = "Unclosed instruction block: remember that " ++ U.bold ++ "you died" ++ U.nocolor
   show MissingAliasListEnd = "Unclosed alias list: be thankful of the " ++ U.bold ++ "help received" ++ U.nocolor
+  show MissingClosingBrace = "Unclosed brace: mismatched { without its closing " ++ U.bold ++ "}" ++ U.nocolor

--- a/src/Grammar.hs
+++ b/src/Grammar.hs
@@ -151,8 +151,10 @@ data GrammarType
 
 data RecoverableError
   = MissingProgramEnd
-  | MissingInstructionEnd
+  | MissingInstructionListEnd
+  | MissingAliasListEnd
 
 instance Show RecoverableError where
   show MissingProgramEnd = "Unclosed program block: forgot to say " ++ U.bold ++ "farewell ashen one" ++ U.nocolor
-  show MissingInstructionEnd = "Unclosed instruction block: remember that " ++ U.bold ++ "you died" ++ U.nocolor
+  show MissingInstructionListEnd = "Unclosed instruction block: remember that " ++ U.bold ++ "you died" ++ U.nocolor
+  show MissingAliasListEnd = "Unclosed alias list: be thankful of the " ++ U.bold ++ "help received" ++ U.nocolor

--- a/src/Parser.y
+++ b/src/Parser.y
@@ -406,11 +406,18 @@ INSTEND
   : instructionsEnd                                                     {% do
                                                                              ST.exitScope
                                                                              return Nothing }
-  | error                                                               {% return $ Just G.MissingInstructionListEnd }
+  | error                                                               { Just G.MissingInstructionListEnd }
 
 DECLARS :: { () }
 DECLARS
-  : with DECLARSL declarend                                             {% addIdsToSymTable (reverse $2) }
+  : with DECLARSL DECLAREND                                             {% do
+                                                                             checkRecoverableError $1 $3
+                                                                             addIdsToSymTable (reverse $2) }
+
+DECLAREND :: { Maybe G.RecoverableError }
+DECLAREND
+  : declarend                                                           { Nothing }
+  | error                                                               { Just G.MissingDeclarationListEnd }
 
 DECLARSL :: { [NameDeclaration] }
 DECLARSL

--- a/src/Parser.y
+++ b/src/Parser.y
@@ -491,12 +491,24 @@ DEFAULTCASE :: { G.SwitchCase }
   : switchDefault colon CODEBLOCK                                       { G.DefaultCase $3 }
 
 FUNCPARS :: { G.Params }
-  : granting PARSLIST toTheKnight                                       { reverse $2 }
+  : granting PARSLIST TOTHEKNIGHT                                       {% do
+                                                                             checkRecoverableError $1 $3
+                                                                             return $ reverse $2 }
   | {- empty -}                                                         { [] }
 
+TOTHEKNIGHT :: { Maybe G.RecoverableError }
+  : toTheKnight                                                         { Nothing }
+  | error                                                               { Just G.MissingFunCallEnd }
+
 PROCPARS :: { G.Params }
-  : offering PARSLIST toTheEstusFlask                                   { reverse $2 }
+  : offering PARSLIST TOTHEESTUSFLASK                                   {% do
+                                                                             checkRecoverableError $1 $3
+                                                                             return $ reverse $2 }
   | {- empty -}                                                         { [] }
+
+TOTHEESTUSFLASK :: { Maybe G.RecoverableError }
+  : toTheEstusFlask                                                     { Nothing }
+  | error                                                               { Just G.MissingProcCallEnd }
 
 PARSLIST :: { G.Params }
   : PARSLIST comma EXPR                                                 { $3 : $1 }

--- a/src/Parser.y
+++ b/src/Parser.y
@@ -174,7 +174,6 @@ import qualified TypeChecking as T
 %%
 
 PROGRAM :: { G.Program }
-PROGRAM
   : programBegin ALIASES METHODS NON_OPENER_CODEBLOCK PROGRAMEND        {% do
                                                                              checkRecoverableError $1 $5
                                                                              return $ G.Program $4 }
@@ -184,7 +183,6 @@ PROGRAMEND :: { Maybe G.RecoverableError }
   | error                                                               { Just G.MissingProgramEnd }
 
 NON_OPENER_CODEBLOCK :: { G.CodeBlock }
-NON_OPENER_CODEBLOCK
   : instructionsBegin DECLARS INSTRL NON_OPENER_INSTEND                 {% do
                                                                              checkRecoverableError $1 $4
                                                                              return $ G.CodeBlock $ reverse $3 }
@@ -193,12 +191,10 @@ NON_OPENER_CODEBLOCK
                                                                              return $ G.CodeBlock $ reverse $2 }
 
 NON_OPENER_INSTEND :: { Maybe G.RecoverableError }
-NON_OPENER_INSTEND
   : instructionsEnd                                                     { Nothing }
   | error                                                               { Just G.MissingInstructionListEnd }
 
 ALIASES :: { () }
-ALIASES
   : aliasListBegin ALIASL ALIASLISTEND                                  {% do
                                                                             checkRecoverableError $1 $3
                                                                             addIdsToSymTable $ reverse $2
@@ -208,21 +204,17 @@ ALIASES
 
 
 ALIASLISTEND :: { Maybe G.RecoverableError }
-ALIASLISTEND
  : aliasListEnd                                                         { Nothing }
  | error                                                                { Just G.MissingAliasListEnd }
 
 ALIASL :: { [NameDeclaration] }
-ALIASL
   : ALIASL comma ALIAS                                                  { $3:$1 }
   | ALIAS                                                               { [$1] }
 
 ALIAS :: { NameDeclaration }
-ALIAS
   : alias ID TYPE                                                       { (ST.Type, $2, $3) }
 
 LVALUE :: { G.Expr }
-LVALUE
   : ID                                                                  {% do
                                                                             checkIdAvailability $1
                                                                             let (G.Id tk) = $1
@@ -236,7 +228,6 @@ LVALUE
   | memAccessor EXPR                                                    {% buildAndCheckExpr $1 $ G.MemAccess $2 }
 
 EXPR :: { G.Expr }
-EXPR
   : intLit                                                              {% buildAndCheckExpr $1 $ G.IntLit (read (L.cleanedString $1) :: Int) }
   | floatLit                                                            {% buildAndCheckExpr $1 $ G.FloatLit (read (L.cleanedString $1) :: Float) }
   | charLit                                                             {% buildAndCheckExpr $1 $ G.CharLit $ head (L.cleanedString $1) }
@@ -273,27 +264,22 @@ EXPR
   | LVALUE                                                              { $1 }
 
 EXPRL :: { [G.Expr] }
-EXPRL
   : {- empty -}                                                         { [] }
   | NONEMPTYEXPRL                                                       { $1 }
 
 NONEMPTYEXPRL :: { [G.Expr] }
-NONEMPTYEXPRL
   : EXPR                                                                { [$1] }
   | NONEMPTYEXPRL comma EXPR                                            { $3:$1 }
 
 METHODS :: { () }
-METHODS
   : {- empty -}                                                         { () }
   | METHODL                                                             { () }
 
 METHODL :: { () }
-METHODL
   : METHODL METHOD                                                      { () }
   | METHOD                                                              { () }
 
 METHOD :: { () }
-METHOD
   : FUNC                                                                {% do
                                                                           (dict, _, s) <- RWS.get
                                                                           RWS.put (dict, [1, 0], s) }
@@ -302,51 +288,41 @@ METHOD
                                                                           RWS.put (dict, [1, 0], s) }
 
 FUNCPREFIX :: { Maybe (ST.Scope, G.Id) }
-FUNCPREFIX
   : functionBegin ID METHODPARS functionType TYPE                       {% addFunction (ST.Function,
                                                                               $2, G.Callable (Just $5) $3) }
 FUNC :: { () }
-FUNC
   : FUNCPREFIX NON_OPENER_CODEBLOCK functionEnd                         {% case $1 of
                                                                             Nothing -> return ()
                                                                             Just (s, i) -> updateCodeBlockOfFun s i $2 }
 
 PROCPREFIX :: { Maybe (ST.Scope, G.Id) }
-PROCPREFIX
   : procedureBegin ID PROCPARSDEC                                       {% addFunction (ST.Procedure,
                                                                               $2, G.Callable Nothing $3) }
 PROC :: { () }
-PROC
   : PROCPREFIX NON_OPENER_CODEBLOCK procedureEnd                        {% case $1 of
                                                                             Nothing -> return ()
                                                                             Just (s, i) -> updateCodeBlockOfFun s i $2 }
 
 PROCPARSDEC :: { [ArgDeclaration] }
-PROCPARSDEC
   : METHODPARS toTheEstusFlask                                          { $1 }
   | {- empty -}                                                         { [] }
 
 METHODPARS :: { [ArgDeclaration] }
-METHODPARS
   : paramRequest PARS                                                   { reverse $2 }
   | {- empty -}                                                         { [] }
 
 PARS :: { [ArgDeclaration] }
-PARS
   : PARS comma PAR                                                      { $3:$1 }
   | PAR                                                                 { [$1] }
 
 PAR :: { ArgDeclaration }
-PAR
   : PARTYPE ID ofType TYPE                                              { ($1, $2, $4) }
 
 PARTYPE :: { G.ArgType }
-PARTYPE
   : parVal                                                              { G.Val }
   | parRef                                                              { G.Ref }
 
 TYPE :: { G.GrammarType }
-TYPE
   : ID                                                                  { let G.Id t = $1 in G.Simple t Nothing }
   | bigInt                                                              { G.Simple $1 Nothing }
   | smallInt                                                            { G.Simple $1 Nothing }
@@ -365,30 +341,24 @@ TYPE
                                                                              return $ G.Record $1 $ reverse $3 }
 
 BRCLOSE :: { Maybe G.RecoverableError }
-BRCLOSE
   : brClose                                                             { Nothing }
   | error                                                               { Just G.MissingClosingBrace }
 
 ENUMITS :: { [Int] }
-ENUMITS
   : ENUMITS comma ID                                                    { [] }
   | ID                                                                  { [] }
 
 STRUCTITS :: { [RecordItem] }
-STRUCTITS
   : STRUCTITS comma STRUCTIT                                            { $3:$1 }
   | STRUCTIT                                                            { [$1] }
 
 STRUCTIT :: { RecordItem }
-STRUCTIT
   : ID ofType TYPE                                                      { ($1, $3) }
 
 ID :: { G.Id }
-ID
   : id                                                                  { G.Id $1 }
 
 CODEBLOCK :: { G.CodeBlock }
-CODEBLOCK
   : INSTBEGIN DECLARS INSTRL INSTEND                                    {% do
                                                                              checkRecoverableError $1 $4
                                                                              return $ G.CodeBlock $ reverse $3 }
@@ -402,45 +372,37 @@ INSTBEGIN : instructionsBegin                                           {% do
                                                                              return $1 }
 
 INSTEND :: { Maybe G.RecoverableError }
-INSTEND
   : instructionsEnd                                                     {% do
                                                                              ST.exitScope
                                                                              return Nothing }
   | error                                                               { Just G.MissingInstructionListEnd }
 
 DECLARS :: { () }
-DECLARS
   : with DECLARSL DECLAREND                                             {% do
                                                                              checkRecoverableError $1 $3
                                                                              addIdsToSymTable (reverse $2) }
 
 DECLAREND :: { Maybe G.RecoverableError }
-DECLAREND
   : declarend                                                           { Nothing }
   | error                                                               { Just G.MissingDeclarationListEnd }
 
 DECLARSL :: { [NameDeclaration] }
-DECLARSL
   : DECLARSL comma DECLAR                                               { $3:$1 }
   | DECLAR                                                              { [$1] }
 
 VARTYPE :: { ST.Category }
-VARTYPE
   : const                                                               { ST.Constant }
   | var                                                                 { ST.Variable }
 
 DECLAR :: { NameDeclaration }
-DECLAR
   : VARTYPE ID ofType TYPE                                              { ($1, $2, $4) }
   | VARTYPE ID ofType TYPE asig EXPR                                    { ($1, $2, $4) }
 
 INSTRL :: { G.Instructions }
-INSTRL
   : INSTRL seq INSTR                                                    { $3 : $1 }
   | INSTR                                                               { [$1] }
 
 INSTR :: { G.Instruction }
-INSTR
   : LVALUE asig EXPR                                                    {% do
                                                                           checkConstantReassignment $1
                                                                           return $ G.InstAsig $1 $3 }
@@ -464,13 +426,11 @@ INSTR
   | forEachBegin ID withTitaniteFrom EXPR CODEBLOCK forEachEnd          { G.InstForEach $2 $4 $5 }
 
 FUNCALL :: { (L.Token, G.Id, G.Params) }
-FUNCALL
   : summon ID FUNCPARS                                                  {% do
                                                                           checkIdAvailability $2
                                                                           return ($1, $2, $3) }
 
 IFCASES :: { G.IfCases }
-IFCASES
   : IFCASES IFCASE                                                      { $2 : $1 }
   | IFCASE                                                              { [$1] }
 

--- a/src/Parser.y
+++ b/src/Parser.y
@@ -357,8 +357,17 @@ TYPE
   | ltelit EXPR string                                                  { G.Simple $3 (Just $2) }
   | set ofType TYPE                                                     { G.Compound $1 $3 Nothing }
   | pointer TYPE                                                        { G.Compound $1 $2 Nothing }
-  | record brOpen STRUCTITS brClose                                     { G.Record $1 $ reverse $3 }
-  | unionStruct brOpen STRUCTITS brClose                                { G.Record $1 $ reverse $3 }
+  | record brOpen STRUCTITS BRCLOSE                                     {% do
+                                                                             checkRecoverableError $2 $4
+                                                                             return $ G.Record $1 $ reverse $3 }
+  | unionStruct brOpen STRUCTITS BRCLOSE                                {% do
+                                                                             checkRecoverableError $2 $4
+                                                                             return $ G.Record $1 $ reverse $3 }
+
+BRCLOSE :: { Maybe G.RecoverableError }
+BRCLOSE
+  : brClose                                                             { Nothing }
+  | error                                                               { Just G.MissingClosingBrace }
 
 ENUMITS :: { [Int] }
 ENUMITS


### PR DESCRIPTION
Adds support for error recovery in following cases:

- MissingProgramEnd
- MissingDeclarationListEnd
- MissingInstructionListEnd
- MissingAliasListEnd
- MissingClosingBrace
- MissingFunCallEnd
- MissingProcCallEnd

Also includes some general but minor fixes.