### PR TITLE
improve error recovery

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -651,7 +651,7 @@ El token `liar!` es equivalente al token `else` de otros lenguajes de programaci
 El lenguaje poseee estructuras condicionales, de tipo switch. La sintaxis es la siguiente:
 
 ```firelink
-enter dungeon with <expresión>
+enter dungeon with <expresión>:
 <expresión 1>:
   <bloque de instrucciones 1>
 [<expresión 2>:

--- a/samples/error_recovery/closing_parens.souls
+++ b/samples/error_recovery/closing_parens.souls
@@ -1,0 +1,15 @@
+hello ashen one
+
+    traveling somewhere
+    with
+        var n of type humanity
+    in your inventory
+        n <<= (1 \
+        n <<= ((1) \
+        n <<= ((1 \
+        n <<= (1) + (2 \
+        n <<= (1 + (2 \
+        n <<= ((1 + 3 * (1 + 4
+    you died
+
+farewell ashen one

--- a/samples/error_recovery/colon.souls
+++ b/samples/error_recovery/colon.souls
@@ -1,0 +1,42 @@
+hello ashen one
+
+traveling somewhere
+
+    while the lit covenant is active
+        traveling somewhere
+            go back
+        you died
+    covenant left \
+
+    trust your inventory
+        lit:
+            traveling somewhere
+                go back
+            you died
+        liar!
+            traveling somewhere
+                go back
+            you died
+    inventory closed \
+
+    enter dungeon with 1
+    1:
+        traveling somewhere
+            go back
+        you died
+    dungeon exited \
+
+    enter dungeon with 1
+    1:
+        traveling somewhere
+            go back
+        you died
+    empty dungeon
+        traveling somewhere
+            go back
+        you died
+    dungeon exited
+
+you died
+
+farewell ashen one

--- a/samples/error_recovery/for_each_end.souls
+++ b/samples/error_recovery/for_each_end.souls
@@ -1,0 +1,16 @@
+hello ashen one
+
+traveling somewhere
+    with
+        var biglist of type <3>-chest of type humanity <<= <$ 1, 2, 3 $>,
+        var i of type humanity
+    in your inventory
+    repairing i with titanite from biglist
+        traveling somewhere
+            with orange saponite say i \
+            with orange saponite say |\n|
+        you died
+
+you died
+
+farewell ashen one

--- a/samples/error_recovery/for_end.souls
+++ b/samples/error_recovery/for_end.souls
@@ -1,0 +1,15 @@
+hello ashen one
+
+traveling somewhere
+    with
+        var i of type humanity <<= 1
+    in your inventory
+    upgrading i with 1 soul until level 20
+        traveling somewhere
+            with orange saponite say i \
+            with orange saponite say |\n|
+        you died
+
+you died
+
+farewell ashen one

--- a/samples/error_recovery/if_end.souls
+++ b/samples/error_recovery/if_end.souls
@@ -1,0 +1,11 @@
+hello ashen one
+
+traveling somewhere
+    trust your inventory
+    lit:
+        traveling somewhere
+            go back
+        you died
+you died
+
+farewell ashen one

--- a/samples/error_recovery/if_end.souls
+++ b/samples/error_recovery/if_end.souls
@@ -6,6 +6,16 @@ traveling somewhere
         traveling somewhere
             go back
         you died
+    \
+    trust your inventory
+    lit:
+        traveling somewhere
+            go back
+        you died
+    liar!:
+        traveling somewhere
+            go back
+        you died
 you died
 
 farewell ashen one

--- a/samples/error_recovery/switch_end.souls
+++ b/samples/error_recovery/switch_end.souls
@@ -1,0 +1,21 @@
+hello ashen one
+
+traveling somewhere
+    enter dungeon with 1:
+    1:
+        traveling somewhere
+            go back
+        you died
+    \
+    enter dungeon with 1:
+    1:
+        traveling somewhere
+            go back
+        you died
+    empty dungeon:
+        traveling somewhere
+            go back
+        you died
+you died
+
+farewell ashen one

--- a/samples/error_recovery/while_end.souls
+++ b/samples/error_recovery/while_end.souls
@@ -1,0 +1,14 @@
+hello ashen one
+
+traveling somewhere
+    with
+        var i of type humanity <<= 1
+    in your inventory
+    while the lit covenant is active:
+        traveling somewhere
+            go back
+        you died
+
+you died
+
+farewell ashen one

--- a/src/Grammar.hs
+++ b/src/Grammar.hs
@@ -187,6 +187,7 @@ data RecoverableError
   | MissingForEachEnd
   | MissingWhileEnd
   | MissingColon
+  | MissingClosingParens
 
 instance Show RecoverableError where
   show MissingProgramEnd = "Unclosed program block: forgot to say " ++ U.bold ++ "farewell ashen one" ++ U.nocolor
@@ -194,6 +195,7 @@ instance Show RecoverableError where
   show MissingInstructionListEnd = "Unclosed instruction block: remember that " ++ U.bold ++ "you died" ++ U.nocolor
   show MissingAliasListEnd = "Unclosed alias list: be thankful of the " ++ U.bold ++ "help received" ++ U.nocolor
   show MissingClosingBrace = "Unclosed brace: mismatched { without its closing " ++ U.bold ++ "}" ++ U.nocolor
+  show MissingClosingParens = "Unclosed parenthesis: mismatched ( without its closing " ++ U.bold ++ ")" ++ U.nocolor
   show MissingFunCallEnd = "Unclosed function call: state your grants " ++ U.bold ++ "to the knight" ++ U.nocolor
   show MissingProcCallEnd = "Unclosed procedure call: state your requests " ++ U.bold ++ "to the estus flask" ++ U.nocolor
   show MissingIfEnd = "Unclosed conditional instruction: leave your " ++ U.bold ++ "inventory closed" ++ U.nocolor

--- a/src/Grammar.hs
+++ b/src/Grammar.hs
@@ -182,6 +182,7 @@ data RecoverableError
   | MissingFunCallEnd
   | MissingProcCallEnd
   | MissingIfEnd
+  | MissingSwitchEnd
 
 instance Show RecoverableError where
   show MissingProgramEnd = "Unclosed program block: forgot to say " ++ U.bold ++ "farewell ashen one" ++ U.nocolor
@@ -192,3 +193,4 @@ instance Show RecoverableError where
   show MissingFunCallEnd = "Unclosed function call: state your grants " ++ U.bold ++ "to the knight" ++ U.nocolor
   show MissingProcCallEnd = "Unclosed procedure call: state your requests " ++ U.bold ++ "to the estus flask" ++ U.nocolor
   show MissingIfEnd = "Unclosed conditional instruction: leave your " ++ U.bold ++ "inventory closed" ++ U.nocolor
+  show MissingSwitchEnd = "Unclosed switch instruction: was the " ++ U.bold ++ "dungeon exited" ++ U.nocolor ++ "?"

--- a/src/Grammar.hs
+++ b/src/Grammar.hs
@@ -181,6 +181,7 @@ data RecoverableError
   | MissingClosingBrace
   | MissingFunCallEnd
   | MissingProcCallEnd
+  | MissingIfEnd
 
 instance Show RecoverableError where
   show MissingProgramEnd = "Unclosed program block: forgot to say " ++ U.bold ++ "farewell ashen one" ++ U.nocolor
@@ -190,3 +191,4 @@ instance Show RecoverableError where
   show MissingClosingBrace = "Unclosed brace: mismatched { without its closing " ++ U.bold ++ "}" ++ U.nocolor
   show MissingFunCallEnd = "Unclosed function call: state your grants " ++ U.bold ++ "to the knight" ++ U.nocolor
   show MissingProcCallEnd = "Unclosed procedure call: state your requests " ++ U.bold ++ "to the estus flask" ++ U.nocolor
+  show MissingIfEnd = "Unclosed conditional instruction: leave your " ++ U.bold ++ "inventory closed" ++ U.nocolor

--- a/src/Grammar.hs
+++ b/src/Grammar.hs
@@ -186,6 +186,7 @@ data RecoverableError
   | MissingForEnd
   | MissingForEachEnd
   | MissingWhileEnd
+  | MissingColon
 
 instance Show RecoverableError where
   show MissingProgramEnd = "Unclosed program block: forgot to say " ++ U.bold ++ "farewell ashen one" ++ U.nocolor
@@ -200,3 +201,4 @@ instance Show RecoverableError where
   show MissingForEnd = "Unclosed bounded iteration: check for " ++ U.bold ++ "max level reached" ++ U.nocolor
   show MissingForEachEnd = "Unclosed structured iteration: have your " ++ U.bold ++ "weaponry repaired" ++ U.nocolor
   show MissingWhileEnd = "Unclosed conditioned iteration: was the " ++ U.bold ++ "covenant left" ++ U.nocolor ++ "?"
+  show MissingColon = "Missing colon (" ++ U.bold ++ ":" ++ U.nocolor ++ ") where it was needed"

--- a/src/Grammar.hs
+++ b/src/Grammar.hs
@@ -185,6 +185,7 @@ data RecoverableError
   | MissingSwitchEnd
   | MissingForEnd
   | MissingForEachEnd
+  | MissingWhileEnd
 
 instance Show RecoverableError where
   show MissingProgramEnd = "Unclosed program block: forgot to say " ++ U.bold ++ "farewell ashen one" ++ U.nocolor
@@ -198,3 +199,4 @@ instance Show RecoverableError where
   show MissingSwitchEnd = "Unclosed switch instruction: was the " ++ U.bold ++ "dungeon exited" ++ U.nocolor ++ "?"
   show MissingForEnd = "Unclosed bounded iteration: check for " ++ U.bold ++ "max level reached" ++ U.nocolor
   show MissingForEachEnd = "Unclosed structured iteration: have your " ++ U.bold ++ "weaponry repaired" ++ U.nocolor
+  show MissingWhileEnd = "Unclosed conditioned iteration: was the " ++ U.bold ++ "covenant left" ++ U.nocolor ++ "?"

--- a/src/Grammar.hs
+++ b/src/Grammar.hs
@@ -183,6 +183,8 @@ data RecoverableError
   | MissingProcCallEnd
   | MissingIfEnd
   | MissingSwitchEnd
+  | MissingForEnd
+  | MissingForEachEnd
 
 instance Show RecoverableError where
   show MissingProgramEnd = "Unclosed program block: forgot to say " ++ U.bold ++ "farewell ashen one" ++ U.nocolor
@@ -194,3 +196,5 @@ instance Show RecoverableError where
   show MissingProcCallEnd = "Unclosed procedure call: state your requests " ++ U.bold ++ "to the estus flask" ++ U.nocolor
   show MissingIfEnd = "Unclosed conditional instruction: leave your " ++ U.bold ++ "inventory closed" ++ U.nocolor
   show MissingSwitchEnd = "Unclosed switch instruction: was the " ++ U.bold ++ "dungeon exited" ++ U.nocolor ++ "?"
+  show MissingForEnd = "Unclosed bounded iteration: check for " ++ U.bold ++ "max level reached" ++ U.nocolor
+  show MissingForEachEnd = "Unclosed structured iteration: have your " ++ U.bold ++ "weaponry repaired" ++ U.nocolor

--- a/src/Parser.y
+++ b/src/Parser.y
@@ -414,7 +414,8 @@ INSTR :: { G.Instruction }
   | returnWith EXPR                                                     { G.InstReturnWith $2 }
   | print EXPR                                                          { G.InstPrint $2 }
   | read LVALUE                                                         { G.InstRead $2 }
-  | whileBegin EXPR covenantIsActive colon CODEBLOCK whileEnd           {% do
+  | whileBegin EXPR covenantIsActive colon CODEBLOCK WHILEEND           {% do
+                                                                            checkRecoverableError $1 $6
                                                                             checkBooleanGuard $2
                                                                             return $ G.InstWhile $2 $5 }
   | ifBegin IFCASES ELSECASE IFEND                                      {% do
@@ -483,6 +484,10 @@ FOREACHBEGIN :: { (T.Token, G.Id, Bool) }
 FOREACHEND :: { Maybe G.RecoverableError }
   : forEachEnd                                                          { Nothing }
   | error                                                               { Just G.MissingForEachEnd }
+
+WHILEEND :: { Maybe G.RecoverableError }
+  : whileEnd                                                            { Nothing }
+  | error                                                               { Just G.MissingWhileEnd }
 
 FUNCALL :: { (T.Token, G.Id, G.Params) }
   : summon ID FUNCPARS                                                  { ($1, $2, $3) }

--- a/src/Parser.y
+++ b/src/Parser.y
@@ -29,11 +29,9 @@ import Utils
 
 %left and or
 
-
 %left colConcat
 %left diff
 %left union intersect
-
 
 %left asciiOf
 %right not
@@ -202,7 +200,6 @@ ALIASES :: { () }
                                                                             (ST.SymTable dict _ s ivs) <- RWS.get
                                                                             RWS.put (ST.SymTable dict [1, 0] s ivs) }
   | {- empty -}                                                         { () }
-
 
 ALIASLISTEND :: { Maybe G.RecoverableError }
  : aliasListEnd                                                         { Nothing }
@@ -645,7 +642,6 @@ addIdToSymTable mi d@(c, gId@(G.Id tk@(T.Token {T.aToken=at, T.cleanedString=idN
         }
       else RWS.tell $ [ST.SemanticError ("Name " ++ idName ++ " was already declared on this scope") tk]
 
-
 insertIdToEntry :: Maybe Int -> G.GrammarType -> ST.DictionaryEntry -> ST.ParserMonad ()
 insertIdToEntry mi t entry = do
   maybeExtra <- buildExtraForType t
@@ -987,7 +983,6 @@ functionsCheck funId exprs tk = do
       then findInvalid xs (i + 1)
       else Just i
 
-
 memAccessCheck :: G.Expr -> T.Token -> ST.ParserMonad T.Type
 memAccessCheck expr tk = do
   t <- getType expr
@@ -1085,7 +1080,6 @@ binaryOpCheck leftExpr rightExpr op tk = do
         RWS.tell [ST.SemanticError (T.typeMismatchMessage tk) tk]
         return (T.TypeError, exp)
 
-
 checkSetSize :: G.Expr -> T.Token -> ST.ParserMonad T.Type
 checkSetSize expr tk = do
   t <- getType expr
@@ -1174,7 +1168,6 @@ instance TypeCheckable ST.DictionaryEntry where
     -- If it is an alias, return just the name
     | cat == ST.Type = return $ T.AliasT (ST.name entry)
 
-
     | cat `elem` [ST.Function, ST.Procedure] = do
       let isEmptyFunction = not . null $ filter ST.isEmptyFunction extras
       range <- (case cat of
@@ -1193,8 +1186,6 @@ instance TypeCheckable ST.DictionaryEntry where
         ST.Variable, ST.Constant,
         ST.RecordItem, ST.UnionItem,
         ST.RefParam, ST.ValueParam] = getType $ ST.extractTypeFromExtra extras
-
-
 
     | otherwise = error "error on getType for dict entries"
 


### PR DESCRIPTION
Closes #35 by fully implementing error recovery. Also fixes a missing colon (:) on the specs.