### PR TITLE
Assignment type checking

### DIFF
--- a/firelink.cabal
+++ b/firelink.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 348bd6bc5565e2fd5e265a6553eeca6d0c3ed03bf5784cfca7c5e4882fda8908
+-- hash: d610eb7e0730140700b21611d164e719928c059ce287f852c7b708d2cfb3456f
 
 name:           firelink
 version:        0.1.0.0
@@ -189,6 +189,7 @@ test-suite type-checking-tests
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
+      AssignmentInstructionSpec
       ForEachInstructionSpec
       IfInstructionSpec
       LoopInstructionsSpec

--- a/samples/type_checking/assignments.souls
+++ b/samples/type_checking/assignments.souls
@@ -1,0 +1,21 @@
+hello ashen one
+
+    traveling somewhere
+    with
+        var a of type humanity,
+        var b of type hollow,
+        var c of type bonfire
+    in your inventory
+        a <<= 1 \
+        a <<= lit \
+        a <<= 4.5 \
+        b <<= 1 \
+        b <<= lit \
+        b <<= 4.5 \
+        c <<= 1 \
+        c <<= lit \
+        c <<= 4.5
+
+    you died
+
+farewell ashen one

--- a/samples/type_checking/assignments.souls
+++ b/samples/type_checking/assignments.souls
@@ -4,7 +4,8 @@ hello ashen one
     with
         var a of type humanity,
         var b of type hollow,
-        var c of type bonfire
+        var c of type bonfire,
+        const d of type humanity <<= 4
     in your inventory
         a <<= 1 \
         a <<= lit \
@@ -14,8 +15,8 @@ hello ashen one
         b <<= 4.5 \
         c <<= 1 \
         c <<= lit \
-        c <<= 4.5
-
+        c <<= 4.5 \
+        d <<= 8
     you died
 
 farewell ashen one

--- a/src/frontend/TypeChecking.hs
+++ b/src/frontend/TypeChecking.hs
@@ -24,7 +24,31 @@ data Type
   | AliasT String
   | Any -- Currently only used in empty set, empty array and null pointers
   | TypeError
-  deriving Show
+
+instance Show Type where
+  show BigIntT = "big humanity"
+  show SmallIntT = "small humanity"
+  show TrileanT = "bonfire"
+  show FloatT = "hollow"
+  show CharT = "sign"
+  show StringT = "miracle"
+  show VoidT = "abyss"
+  show (ArrayT t) = "chest of type " ++ show t
+  show (SetT t) = "armor of type " ++ show t
+  show (RecordT ps) = "link with elements " ++ formattedElements
+    where elements = concatMap (\(PropType (a, t)) -> a ++ " of type " ++ show t ++ ", ") ps
+          usefulChars = length elements - 2
+          formattedElements = take usefulChars elements
+  show (UnionT ps) = "link with elements " ++ formattedElements
+    where elements = concatMap (\(PropType (a, t)) -> a ++ " of type " ++ show t ++ ", ") ps
+          usefulChars = length elements - 2
+          formattedElements = take usefulChars elements
+  show (PointerT t) = "arrow to " ++ show t
+  show (FunctionT as r) = "spell requiring " ++ concatMap (\t -> show t ++ ", ") as ++ " and returning " ++ show r
+  show (TypeList ts) = "typelist " ++ concatMap (\t -> show t ++ ", ") ts
+  show (AliasT t) = "knight to " ++ t
+  show Any = "any"
+  show TypeError = "error type (if you see this, open an issue on github)"
 
 instance Eq Type where
   BigIntT == BigIntT = True

--- a/test/TypeChecking/AssignmentInstructionSpec.hs
+++ b/test/TypeChecking/AssignmentInstructionSpec.hs
@@ -1,0 +1,31 @@
+module AssignmentInstructionSpec where
+
+import Test.Hspec
+import qualified TestUtils as U
+
+baseProgram :: String -> String -> String -> String
+baseProgram c t e = "hello ashen one\n\
+
+\traveling somewhere \n\
+\with\n\
+\   " ++ c ++ " x of type " ++ t ++ "\n\
+\in your inventory\n\
+\   x <<= " ++ e ++ "\n\
+\you died\n\
+
+\farewell ashen one"
+
+spec :: Spec
+spec =
+  describe "`assignments`" $ do
+    it "should accept an assignment with an exactly-matching type" $
+      U.shouldNotError $ baseProgram "var" "humanity" "3"
+
+    it "should accept an assignment with an castable type" $
+      U.shouldNotError $ baseProgram "var" "hollow" "3"
+
+    it "should reject an assignment with a non-castable type" $
+      baseProgram "var" "bonfire" "3" `U.shouldErrorOn` ("<<=", 6, 6)
+
+    it "should reject an assignment to a constant" $
+      baseProgram "const" "bonfire <<= lit" "lit" `U.shouldErrorOn` ("<<=", 6, 4)

--- a/test/test-utils/TestUtils.hs
+++ b/test/test-utils/TestUtils.hs
@@ -110,7 +110,7 @@ shouldNotError p = do
     errors `shouldSatisfy` null
 
 shouldErrorOn :: String -> (String, Int, Int) -> IO ()
-shouldErrorOn program (varName, row', col) = do
+shouldErrorOn program (_, row', col) = do
     errors <- extractErrors program
     errors `shouldNotSatisfy` null
     let Error _ posn = head errors


### PR DESCRIPTION
This PR introduces the following changes:

- Assignment typechecking was refactored and extended not only to initialized-on-declaration vars.
- Assignment typechecking message was improved showing the types that could not be matched
- Adds a new test case

Fixes #57 