### PR TITLE
Interact with `union` data types and their active attrs

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -293,9 +293,49 @@ link {
 }
 ```
 
-Donde `n` es la cantidad de tipos *distintos entre sí* de la unión, cada una con un nombre *único* para el mismo registro, independientemente de los tipos.
+Donde `n` es la cantidad de tipos de la unión, cada una con un nombre *único* para el mismo registro, independientemente de los tipos.
 
-El valor por defecto de una unión corresponde al valor por defecto de alguno de sus tipos.
+##### Funciones de las uniones
+
+Se debe implementar la siguiente función en el preludio de **FireLink**.
+
+- `is_active`: Recibe un atributo de una unión (`link`) y retorna un `bonfire` de la siguiente manera:
+  - `lit` si el atributo es el atributo activo de la unión
+  - `unlit` si el atributo NO es el atributo activo de la unión
+  - `undiscovered` si ningún valor ha sido asignado aún a algún atributo de la unión
+
+Un ejemplo de su uso sería el siguiente (con algunas libertades en la sintaxis):
+
+```firelink
+
+-- Asumimos que tenemos la siguiente declaración, aún sin inicializar
+var x of type link {
+  a of type humanity,
+  b of type humanity,
+  c of type bonfire
+}
+
+-- Antes de asignar algún valor
+summon is_active granting x~>a to the knight -- undiscovered
+summon is_active granting x~>b to the knight -- undiscovered
+summon is_active granting x~>c to the knight -- undiscovered
+
+-- Asignamos
+x~>a <<= 3
+
+-- Verificamos el atributo activo
+summon is_active granting x~>a to the knight -- lit
+summon is_active granting x~>b to the knight -- unlit
+summon is_active granting x~>c to the knight -- unlit
+
+-- Reasignamos
+x~>c <<= lit
+
+-- Verificamos el atributo activo
+summon is_active granting x~>a to the knight -- unlit
+summon is_active granting x~>b to the knight -- unlit
+summon is_active granting x~>c to the knight -- lit
+```
 
 ### Especiales
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -189,7 +189,7 @@ El valor por defecto de un caracter es el caracter nulo (`|\0|`).
 
 ##### Funciones de los caracteres
 
-Se debe implementar la siguiente función en el preludio de **FireLink**.
+Se debe implementar la siguiente función especial en el preludio de **FireLink**.
 
 - `ascii_of`: Retorna el código ascii de la variable (como `humanity`).
 
@@ -213,7 +213,7 @@ Se cuenta con el siguiente operador:
 
 ##### Funciones de las cadenas de caracteres
 
-Se debe implementar la siguiente función en el preludio de **FireLink**.
+Se debe implementar la siguiente función especial en el preludio de **FireLink**.
 
 - `ascii_of`: Retorna un arreglo de `humanity`s, representando los códigos asciis de cada caracter en el input.
 
@@ -297,7 +297,7 @@ Donde `n` es la cantidad de tipos de la unión, cada una con un nombre *único* 
 
 ##### Funciones de las uniones
 
-Se debe implementar la siguiente función en el preludio de **FireLink**.
+Se debe implementar la siguiente función especial en el preludio de **FireLink**.
 
 - `is_active`: Recibe un atributo de una unión (`link`) y retorna un `bonfire` de la siguiente manera:
   - `lit` si el atributo es el atributo activo de la unión
@@ -316,25 +316,25 @@ var x of type link {
 }
 
 -- Antes de asignar algún valor
-summon is_active granting x~>a to the knight -- undiscovered
-summon is_active granting x~>b to the knight -- undiscovered
-summon is_active granting x~>c to the knight -- undiscovered
+is_active x~>a -- undiscovered
+is_active x~>b -- undiscovered
+is_active x~>c -- undiscovered
 
 -- Asignamos
 x~>a <<= 3
 
 -- Verificamos el atributo activo
-summon is_active granting x~>a to the knight -- lit
-summon is_active granting x~>b to the knight -- unlit
-summon is_active granting x~>c to the knight -- unlit
+is_active x~>a -- lit
+is_active x~>b -- unlit
+is_active x~>c -- unlit
 
 -- Reasignamos
 x~>c <<= lit
 
 -- Verificamos el atributo activo
-summon is_active granting x~>a to the knight -- unlit
-summon is_active granting x~>b to the knight -- unlit
-summon is_active granting x~>c to the knight -- lit
+is_active x~>a -- unlit
+is_active x~>b -- unlit
+is_active x~>c -- lit
 ```
 
 ### Especiales

--- a/src/frontend/Grammar.hs
+++ b/src/frontend/Grammar.hs
@@ -40,6 +40,7 @@ data BaseExpr
   | MemAccess Expr
   | IdExpr Id
   | AsciiOf Expr
+  | IsActive Expr
   | SetSize Expr
   | EvalFunc Id Params
   | Caster Expr Type
@@ -118,6 +119,7 @@ instance Show BaseExpr where
   show (MemAccess e) = "throw a " ++ show e
   show (IdExpr i) = show i
   show (AsciiOf e) = "ascii_of " ++ show e
+  show (IsActive e) = "is_active " ++ show e
   show (SetSize s) = "size " ++ show s
   show (EvalFunc i p) = "summon " ++ show i ++ " granting " ++ joinExprList p ++ " to the knight"
   show (Caster a _) = "(casting) " ++ show a

--- a/src/frontend/Lexer.x
+++ b/src/frontend/Lexer.x
@@ -54,6 +54,7 @@ tokens :-
     inventory\ closed                     { makeToken TkEndIf }
 
     ascii_of                              { makeToken TkAsciiOf }
+    is_active                             { makeToken TkIsActive }
 
     -- switch statements
     enter\ dungeon\ with                  { makeToken TkSwitch }

--- a/src/frontend/Parser.y
+++ b/src/frontend/Parser.y
@@ -1054,14 +1054,16 @@ checkIsActive e tk = do
   case t of
     T.TypeError -> return T.TypeError
     _ ->
-      if isUnionAttr e then return T.TrileanT
+      if isUnionAttr then return T.TrileanT
       else do
         RWS.tell [Error ("is_active requires argument to be a union attribute") (T.position tk)]
         return T.TypeError
-  where isUnionAttr (G.Expr {G.expAst=(G.Access r _)}) = isUnion r
-        isUnionAttr _ = False
-        isUnion (G.Expr {G.expType=(T.UnionT _)}) = True
-        isUnion _ = False
+  where
+    isUnionAttr = case e of
+      (G.Expr {G.expAst=(G.Access r _)}) -> isUnion r
+      _ -> False
+    isUnion (G.Expr {G.expType=(T.UnionT _)}) = True
+    isUnion _ = False
 
 checkAccess :: G.Expr -> G.Id -> T.Token -> ST.ParserMonad T.Type
 checkAccess e (G.Id T.Token{T.cleanedString=i}) tk = do

--- a/src/frontend/Parser.y
+++ b/src/frontend/Parser.y
@@ -34,6 +34,7 @@ import Errors
 %left diff
 %left union intersect
 
+%left isActive
 %left asciiOf
 %right not
 %left accessor
@@ -154,6 +155,7 @@ import Errors
   and                                                                   { T.Token {T.aToken=T.TkAnd} }
   or                                                                    { T.Token {T.aToken=T.TkOr} }
   asciiOf                                                               { T.Token {T.aToken=T.TkAsciiOf} }
+  isActive                                                              { T.Token {T.aToken=T.TkIsActive} }
   colConcat                                                             { T.Token {T.aToken=T.TkConcat} }
   union                                                                 { T.Token {T.aToken=T.TkUnion} }
   intersect                                                             { T.Token {T.aToken=T.TkIntersect} }
@@ -239,6 +241,7 @@ EXPR :: { G.Expr }
   | minus EXPR                                                          {% buildAndCheckExpr $1 $ G.Op1 G.Negate $2 }
   | not EXPR                                                            {% buildAndCheckExpr $1 $ G.Op1 G.Not $2 }
   | asciiOf EXPR                                                        {% buildAndCheckExpr $1 $ G.AsciiOf $2 }
+  | isActive EXPR                                                       {% buildAndCheckExpr $1 $ G.IsActive $2 }
   | size EXPR                                                           {% buildAndCheckExpr $1 $ G.SetSize $2 }
   | EXPR plus EXPR                                                      {% buildAndCheckExpr $2 $ G.Op2 G.Add $1 $3 }
   | EXPR minus EXPR                                                     {% buildAndCheckExpr $2 $ G.Op2 G.Substract $1 $3 }
@@ -1045,6 +1048,20 @@ checkAsciiOf e tk = do
       RWS.tell [Error ("ascii_of requires argument to be a miracle or a sign") (T.position tk)]
       return T.TypeError
 
+checkIsActive :: G.Expr -> T.Token -> ST.ParserMonad T.Type
+checkIsActive e tk = do
+  t <- getType e
+  case t of
+    T.TypeError -> return T.TypeError
+    _ ->
+      if isUnionAttr e then return T.TrileanT
+      else do
+        RWS.tell [Error ("is_active requires argument to be a union attribute") (T.position tk)]
+        return T.TypeError
+  where isUnionAttr (G.Expr {G.expAst=(G.Access r _)}) = isUnion r
+        isUnionAttr _ = False
+        isUnion (G.Expr {G.expType=(T.UnionT _)}) = True
+        isUnion _ = False
 
 checkAccess :: G.Expr -> G.Id -> T.Token -> ST.ParserMonad T.Type
 checkAccess e (G.Id T.Token{T.cleanedString=i}) tk = do
@@ -1190,6 +1207,7 @@ buildType bExpr tk = case bExpr of
   G.IndexAccess e i -> buildTypeForNonCasterExprs (checkIndexAccess e i tk) bExpr
   G.EvalFunc i params -> functionsCheck i params tk
   G.MemAccess e -> buildTypeForNonCasterExprs (memAccessCheck e tk) bExpr
+  G.IsActive e -> buildTypeForNonCasterExprs (checkIsActive e tk) bExpr
   G.AsciiOf e -> buildTypeForNonCasterExprs (checkAsciiOf e tk) bExpr
   G.Access e i -> buildTypeForNonCasterExprs (checkAccess e i tk) bExpr
   G.SetSize e -> buildTypeForNonCasterExprs (checkSetSize e tk) bExpr

--- a/src/frontend/Tokens.hs
+++ b/src/frontend/Tokens.hs
@@ -33,7 +33,7 @@ data AbstractToken = TkId | TkConst | TkVar | TkOfType | TkAsig
     -- Records (C-like structs)
     | TkRecord | TkBraceOpen | TkBraceClose | TkComma | TkAccessor
     -- Unions
-    | TkUnionStruct
+    | TkUnionStruct | TkIsActive
     -- Null, pointer stuff
     | TkNull | TkPointer | TkRequestMemory | TkAccessMemory | TkFreeMemory
     -- Type Aliases

--- a/test/Lexer/StructuredTypesSpec.hs
+++ b/test/Lexer/StructuredTypesSpec.hs
@@ -18,3 +18,9 @@ spec = describe "Lexer" $ do
     let ([], toks) = scanTokens x
     let atok = getAbstractToken $ head toks
     atok `shouldBe` TkUnionStruct
+
+  it "accepts `is_active` as a valid token" $ do
+    let x = "is_active"
+    let ([], toks) = scanTokens x
+    let atok = getAbstractToken $ head toks
+    atok `shouldBe` TkIsActive


### PR DESCRIPTION
This PR fixes #43 as it introduces a new prelude special function that lets you check which element of an union is the active one at a given moment. The behavior is described in the specs, and the function is added to the Lexer, Parser and Semantic Analyser, with proper type checking.

It is recommended to first merge #58 and let the tests run again.