### PR TITLE
add scope found id

### DIFF
--- a/src/backend/ExprCodeGenerator.hs
+++ b/src/backend/ExprCodeGenerator.hs
@@ -49,7 +49,7 @@ genCodeForExpr t (IntLit n) = do
             }]
     return lvalue
 
-genCodeForExpr t (IdExpr (Id Token {cleanedString=s})) = return $ TAC.Constant (s, t)
+genCodeForExpr t (IdExpr (Id Token {cleanedString=s} _)) = return $ TAC.Constant (s, t)
 
 -- TODO: Do type casting correctly
 genCodeForExpr t (Caster expr _) = genCode' expr

--- a/src/frontend/Grammar.hs
+++ b/src/frontend/Grammar.hs
@@ -10,15 +10,15 @@ type Params = [Expr]
 type IfCases = [IfCase]
 type SwitchCases = [SwitchCase]
 
-newtype Id
-  = Id Token
+data Id
+  = Id Token Int
   deriving Eq
 
 extractIdName :: Id -> String
-extractIdName (Id Token {cleanedString=s}) = s
+extractIdName (Id Token {cleanedString=s} _) = s
 
 instance Show Id where
-  show (Id tk) = show tk
+  show (Id tk s) = show tk ++ ":" ++ show s
 
 data BaseExpr
   -- Literals

--- a/src/frontend/TypeChecking.hs
+++ b/src/frontend/TypeChecking.hs
@@ -16,8 +16,8 @@ data Type
   | VoidT
   | ArrayT Type
   | SetT Type
-  | RecordT [PropType]
-  | UnionT [PropType]
+  | RecordT Int [PropType]
+  | UnionT Int [PropType]
   | PointerT Type
   | FunctionT [Type] Type
   | TypeList [Type]
@@ -35,11 +35,11 @@ instance Show Type where
   show VoidT = "abyss"
   show (ArrayT t) = "chest of type " ++ show t
   show (SetT t) = "armor of type " ++ show t
-  show (RecordT ps) = "link with elements " ++ formattedElements
+  show (RecordT _ ps) = "link with elements " ++ formattedElements
     where elements = concatMap (\(PropType (a, t)) -> a ++ " of type " ++ show t ++ ", ") ps
           usefulChars = length elements - 2
           formattedElements = take usefulChars elements
-  show (UnionT ps) = "link with elements " ++ formattedElements
+  show (UnionT _ ps) = "link with elements " ++ formattedElements
     where elements = concatMap (\(PropType (a, t)) -> a ++ " of type " ++ show t ++ ", ") ps
           usefulChars = length elements - 2
           formattedElements = take usefulChars elements
@@ -59,8 +59,8 @@ instance Eq Type where
   StringT == StringT = True
   ArrayT t == ArrayT t' = t == t'
   SetT t == SetT t' = t == t'
-  UnionT pt == UnionT pt' = sort pt == sort pt'
-  RecordT pt == RecordT pt' = sort pt == sort pt'
+  UnionT s pt == UnionT s' pt' = sort pt == sort pt' && s == s'
+  RecordT s pt == RecordT s' pt' = sort pt == sort pt' && s == s'
   PointerT t == PointerT t' = t == t'
   FunctionT ts t == FunctionT ts' t' = ts == ts' && t == t'
   TypeList t == TypeList t' = t == t'

--- a/test/Parser/BoundedLoopStructuresSpec.hs
+++ b/test/Parser/BoundedLoopStructuresSpec.hs
@@ -30,5 +30,5 @@ spec = describe "Bounded loop structures" $ do
         \       with orange saponite say @hello@ \
         \   you died \
         \ max level reached") (\(Program (CodeBlock [
-            InstFor (Id Token {cleanedString="aa"}) Expr{expAst=(IntLit 2)} Expr{expAst=(IntLit 123)} (CodeBlock _)
+            InstFor (Id Token {cleanedString="aa"} _) Expr{expAst=(IntLit 2)} Expr{expAst=(IntLit 123)} (CodeBlock _)
         ])) -> True)

--- a/test/Parser/ConditionalStructuresSpec.hs
+++ b/test/Parser/ConditionalStructuresSpec.hs
@@ -109,7 +109,7 @@ spec = do
             \ 1: \
             \   traveling somewhere \
             \       with orange saponite say @hello@ \
-            \   you died") (\(Program (CodeBlock [InstSwitch Expr{expAst=(IdExpr (Id Token {cleanedString="a"}))} [
+            \   you died") (\(Program (CodeBlock [InstSwitch Expr{expAst=(IdExpr (Id Token {cleanedString="a"} _))} [
                     Case Expr{expAst=(IntLit 1)} (CodeBlock [InstPrint Expr{expAst=(StringLit "hello")}])
                 ]])) -> True)
 
@@ -136,7 +136,7 @@ spec = do
             \ 2: \
             \   traveling somewhere \
             \       with orange saponite say @bye@ \
-            \   you died") (\(Program (CodeBlock [InstSwitch Expr{expAst=(IdExpr (Id Token {cleanedString="a"}))} [
+            \   you died") (\(Program (CodeBlock [InstSwitch Expr{expAst=(IdExpr (Id Token {cleanedString="a"} _))} [
                     Case Expr{expAst=(IntLit 1)} (CodeBlock [InstPrint Expr{expAst=(StringLit "hello")}]),
                     Case Expr{expAst=(IntLit 2)} (CodeBlock [InstPrint Expr{expAst=(StringLit "bye")}])
                 ]])) -> True)
@@ -154,7 +154,7 @@ spec = do
             \ empty dungeon: \
             \   traveling somewhere \
             \       with orange saponite say @empty@ \
-            \   you died") (\(Program (CodeBlock [InstSwitch Expr{expAst=IdExpr (Id Token {cleanedString="a"})} [
+            \   you died") (\(Program (CodeBlock [InstSwitch Expr{expAst=IdExpr (Id Token {cleanedString="a"} _)} [
                     Case Expr{expAst=(IntLit 1)} (CodeBlock [InstPrint Expr{expAst=StringLit "hello"}]),
                     Case Expr{expAst=(IntLit 2)} (CodeBlock [InstPrint Expr{expAst=StringLit "bye"}]),
                     DefaultCase (CodeBlock [InstPrint Expr{expAst=(StringLit "empty")}])

--- a/test/Parser/ExpressionsSpec.hs
+++ b/test/Parser/ExpressionsSpec.hs
@@ -500,8 +500,8 @@ spec = describe "Expressions" $ do
             CodeBlock
                 [InstReturnWith Expr{expAst=(
                     Access
-                        Expr{expAst=(IdExpr (Id Token {cleanedString="a"}))}
-                        (Id Token {cleanedString="b"})
+                        Expr{expAst=(IdExpr (Id Token {cleanedString="a"} _))}
+                        (Id Token {cleanedString="b"} _)
                     )}
                 ])) -> True)
     it "accepts `a ~> b ~> c` as an expression" $
@@ -510,40 +510,40 @@ spec = describe "Expressions" $ do
                 [InstReturnWith Expr{expAst=(
                     Access
                         Expr{expAst=(Access
-                            Expr{expAst=(IdExpr (Id Token {cleanedString="a"}))}
-                            (Id Token {cleanedString="b"}))}
-                        (Id Token {cleanedString="c"}))}])) -> True)
+                            Expr{expAst=(IdExpr (Id Token {cleanedString="a"} _))}
+                            (Id Token {cleanedString="b"} _))}
+                        (Id Token {cleanedString="c"} _))}])) -> True)
     it "accepts `a + b ~> c` as an expression" $
         runTestForExpr "a + b ~> c" (\(Program (
             CodeBlock
                 [InstReturnWith Expr{expAst=(
                     Op2 Add
-                        Expr{expAst=(IdExpr (Id Token {cleanedString="a"}))}
+                        Expr{expAst=(IdExpr (Id Token {cleanedString="a"} _))}
                         Expr{expAst=(Access
-                            Expr{expAst=(IdExpr (Id Token {cleanedString="b"}))}
-                            (Id Token {cleanedString="c"}))})}])) -> True)
+                            Expr{expAst=(IdExpr (Id Token {cleanedString="b"} _))}
+                            (Id Token {cleanedString="c"} _))})}])) -> True)
 
     it "accepts `(a)` as an expression" $
         runTestForExpr "(a)" (\(Program (
             CodeBlock
-                [InstReturnWith Expr{expAst=(IdExpr (Id Token {cleanedString="a"}))}])) -> True)
+                [InstReturnWith Expr{expAst=(IdExpr (Id Token {cleanedString="a"} _))}])) -> True)
 
     it "accepts `a<$i$>` as an expression" $
         runTestForExpr "a<$i$>" (\(Program (
             CodeBlock
                 [InstReturnWith Expr{expAst=(
                     IndexAccess
-                        Expr{expAst=(IdExpr (Id Token {cleanedString="a"}))}
-                        Expr{expAst=(IdExpr (Id Token {cleanedString="i"}))})}])) -> True)
+                        Expr{expAst=(IdExpr (Id Token {cleanedString="a"} _))}
+                        Expr{expAst=(IdExpr (Id Token {cleanedString="i"} _))})}])) -> True)
     it "accepts `a+b<$i$>` as an expression" $
         runTestForExpr "a+b<$i$>" (\(Program (
             CodeBlock
                 [InstReturnWith
                     Expr{expAst=Op2 Add
-                        Expr{expAst=(IdExpr (Id Token {cleanedString="a"}))}
+                        Expr{expAst=(IdExpr (Id Token {cleanedString="a"} _))}
                         Expr{expAst=(IndexAccess
-                            Expr{expAst=(IdExpr (Id Token {cleanedString="b"}))}
-                            Expr{expAst=(IdExpr (Id Token {cleanedString="i"}))})
+                            Expr{expAst=(IdExpr (Id Token {cleanedString="b"} _))}
+                            Expr{expAst=(IdExpr (Id Token {cleanedString="i"} _))})
                         }
                     }])) -> True)
     it "rejects `a<$$>` as an expression" $
@@ -558,7 +558,7 @@ spec = describe "Expressions" $ do
             CodeBlock
                 [InstReturnWith Expr {
                     expAst=MemAccess Expr {
-                        expAst=IdExpr (Id Token {cleanedString="a"})
+                        expAst=IdExpr (Id Token {cleanedString="a"} _)
                     }}])) -> True)
     it "rejects `aim a a` as an expression" $
         runTestForInvalidProgram "aim a a"
@@ -568,4 +568,4 @@ spec = describe "Expressions" $ do
     it "accepts `summon f` a an expression" $
         runTestForExpr "summon f" (\(Program (
             CodeBlock
-                [InstReturnWith Expr{expAst=EvalFunc (Id Token {cleanedString="f"}) []}])) -> True)
+                [InstReturnWith Expr{expAst=EvalFunc (Id Token {cleanedString="f"} _) []}])) -> True)

--- a/test/Parser/ForEachLoopStructuresSpec.hs
+++ b/test/Parser/ForEachLoopStructuresSpec.hs
@@ -31,6 +31,6 @@ spec = describe "Loops over structures" $ do
         \ you died \
         \ weaponry repaired") (\(Program (
             CodeBlock [
-                InstForEach (Id Token {cleanedString="a"}) Expr{expAst=IdExpr (Id Token {cleanedString="b"})}
+                InstForEach (Id Token {cleanedString="a"} _) Expr{expAst=IdExpr (Id Token {cleanedString="b"} _)}
                     (CodeBlock [InstPrint Expr{expAst=StringLit ""}])
                 ])) -> True)

--- a/test/Parser/InstructionsSpec.hs
+++ b/test/Parser/InstructionsSpec.hs
@@ -39,10 +39,10 @@ spec = describe "Instructions" $ do
 
         \ farewell ashen one" (\(Program (CodeBlock [
             InstPrint Expr{expAst=(StringLit "hello world")},
-            InstRead Expr{expAst=(IdExpr (Id Token {cleanedString="patata"}))}])) -> True)
+            InstRead Expr{expAst=(IdExpr (Id Token {cleanedString="patata"} _))}])) -> True)
 
     it "accepts assigning as an instruction" $
         runTestForValidProgram (buildProgram "a <<= 1")
         (\(Program (CodeBlock [
-            InstAsig Expr{expAst=(IdExpr (Id Token {cleanedString="a"}))} Expr{expAst=(IntLit 1)}
+            InstAsig Expr{expAst=(IdExpr (Id Token {cleanedString="a"} _))} Expr{expAst=(IntLit 1)}
         ])) -> True)


### PR DESCRIPTION
This attempts to be a solution to fix #62 

Saving the whole SymEntry is really complicated, resulting in a really poor code. So we need to query the params on each id occurence of the AST at TAC generation time