### PR TITLE
Feature/record & union literals

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -277,6 +277,23 @@ El acceso a una propiedad de nombre `prop` de un registro `a` se realiza mediant
 
 Por defecto, todas las _propiedades_ de un registro se inicializan al valor por defecto correspondiente según el tipo.
 
+Los literales de registros (`bezel literals`) son expresiones de la siguiente forma (con indentación agregada para mayor legibilidad):
+
+```firelink
+{
+  <nombre 1> <<= <valor 1>,
+  <nombre 2> <<= <valor 2>,
+  ...
+  <nombre n> <<= <valor n>
+}
+```
+
+Donde `n` es la cantidad de _propiedades_ del tipo registro al cuál pertenece, cada una con una expresión (valor) asignada. Estos literales, para considerarse válidos, deben cumplir que:
+
+- Tienen exactamente la misma cantidad de propiedades que el tipo registro al cual se están asignando
+- Todos los nombres del tipo registro determinado están presentes en el literal de registro (sin importar el orden)
+- Los tipos de las expresiones corresponden al tipo al cuál está asociado su nombre en el tipo registro determinado
+
 #### Unión
 
 Representa un valor que puede ser de algún tipo entre varios, bajo un mismo nombre en un mismo bloque de memoria. Su declarador de tipo es `link`.
@@ -294,6 +311,16 @@ link {
 ```
 
 Donde `n` es la cantidad de tipos de la unión, cada una con un nombre *único* para el mismo registro, independientemente de los tipos.
+
+Los literales de uniones (`link literals`) son expresiones de la siguiente forma (con indentación agregada para mayor legibilidad):
+
+```firelink
+{
+  <nombre> <<= <valor>
+}
+```
+
+Donde `nombre` corresponde a _alguno_ de los nombres válidos del tipo unión al cuál pertenece, y valor es una expresión cuyo tipo equivale al tipo asociado con el nombre en el tipo unión. No se considerarán válidos literales de uniones que tengan más de un par nombre/valor, que tengan un nombre que no exista en el tipo unión, o cuya expresión pertenezca a un tipo incompatible con el tipo asociado al nombre declarado.
 
 ##### Funciones de las uniones
 

--- a/firelink.cabal
+++ b/firelink.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 8f7c300b7f90939d74cf2b470e5f33df1d356e1abee0d64aed19d79f3abdcb60
+-- hash: 13044788a199dd9fd2301b72bc5c57055f927ab9fc9963f46635b0245f6aab7f
 
 name:           firelink
 version:        0.1.0.0
@@ -194,6 +194,7 @@ test-suite type-checking-tests
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
+      AccessSpec
       AssignmentInstructionSpec
       DeclarationsSpec
       ForEachInstructionSpec

--- a/firelink.cabal
+++ b/firelink.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 13044788a199dd9fd2301b72bc5c57055f927ab9fc9963f46635b0245f6aab7f
+-- hash: 58deab76635e0c4e50402c0260001fa2944aadb2bc97fba361a3567c7bf95bb1
 
 name:           firelink
 version:        0.1.0.0
@@ -202,6 +202,7 @@ test-suite type-checking-tests
       IfInstructionSpec
       LoopInstructionsSpec
       ProceduresSpec
+      StructsSpec
       SwitchInstructionSpec
       WhileInstructionSpec
       TestUtils

--- a/samples/type_checking/accesses.souls
+++ b/samples/type_checking/accesses.souls
@@ -1,0 +1,23 @@
+hello ashen one
+
+requiring help of
+    knight bez bezel { a of type humanity, b of type hollow },
+    knight lez link { i of type humanity, j of type hollow },
+    knight yez bez,
+    knight nay humanity
+help received
+
+traveling somewhere
+with
+    var x of type bez,
+    var z of type yez,
+    var p of type nay,
+    var y of type bezel { a of type humanity, b of type hollow }
+in your inventory
+    x~>a <<= 1 \
+    y~>a <<= 2 \
+    z~>a <<= 3 \
+    p~>a <<= 3
+you died
+
+farewell ashen one

--- a/samples/type_checking/struct_literals.souls
+++ b/samples/type_checking/struct_literals.souls
@@ -1,0 +1,35 @@
+hello ashen one
+
+requiring help of
+    knight bez bezel { a of type humanity, b of type hollow },
+    knight lez link { i of type humanity, j of type hollow }
+help received
+
+traveling somewhere
+with
+    var x of type bez,
+    var y of type lez
+in your inventory
+    x <<= {a <<= 1, b <<= 5.6} \
+    y <<= {i <<= 3} \
+
+    -- Error: less args
+    x <<= {a <<= 1} \
+
+    -- Error: more args
+    x <<= {a <<= 1, b <<= 5, c <<= |?| } \
+
+    -- Error: not exactly 1 arg
+    y <<= {i <<= 1, j <<= 3} \
+
+    -- Error: invalid names
+    x <<= {p <<= 1, a <<= 1} \
+    y <<= {a <<= 9} \
+
+    -- Error: invalid types
+    x <<= {a <<= 9.1, b <<= |a| } \
+    x <<= {a <<= 9.1, b <<= 8.1 } \
+    y <<= { i <<= @fish@ }
+you died
+
+farewell ashen one

--- a/src/frontend/Grammar.hs
+++ b/src/frontend/Grammar.hs
@@ -32,6 +32,7 @@ data BaseExpr
   | StringLit String
   | ArrayLit [Expr]
   | SetLit [Expr]
+  | StructLit [(Id, Expr)]
 
   | Op1 Op1 Expr
   | Op2 Op2 Expr Expr
@@ -101,6 +102,9 @@ instance Show Op2 where
 joinExprList :: [Expr] -> String
 joinExprList = intercalate ", " . map show
 
+joinProps :: [(Id, Expr)] -> String
+joinProps = intercalate ", " . map (\(i, e) -> show i ++ " <<= " ++ show e)
+
 instance Show BaseExpr where
   show TrueLit = "lit"
   show FalseLit = "unlit"
@@ -111,6 +115,7 @@ instance Show BaseExpr where
   show (CharLit a) = [a]
   show (StringLit s) = s
   show (ArrayLit exprs) = "<$" ++ joinExprList exprs ++ "$>"
+  show (StructLit props) = "{ ++ " ++ joinProps props ++ " }"
   show (SetLit exprs) = "{$" ++ joinExprList exprs ++ "$}"
   show (Op1 o e) = show o ++ " " ++ show e
   show (Op2 o e e') = show e ++ " " ++ show o ++ " " ++ show e'

--- a/src/frontend/Parser.y
+++ b/src/frontend/Parser.y
@@ -916,7 +916,7 @@ checkRecoverableError openTk maybeErr = do
       logSemError (errorName ++ " (recovered from to continue parsing)") openTk
 
 extractFieldsFromExtra :: [ST.Extra] -> ST.Extra
-extractFieldsFromExtra [] = logRTErrorF "The `extra` array doesn't have any `Fields` item"
+extractFieldsFromExtra [] = error $ "The `extra` array doesn't have any `Fields` item"
 extractFieldsFromExtra (s@ST.Fields{} : _) = s
 extractFieldsFromExtra (_:ss) = extractFieldsFromExtra ss
 
@@ -1573,15 +1573,15 @@ buildStruct t scope = do
 logSemError :: String -> T.Token -> ST.ParserMonad ()
 logSemError msg tk = RWS.tell [Error msg (T.position tk)]
 
-logRTError :: String -> ST.ParserMonad (a)
-logRTError msg = return $ logRTErrorF msg
-
-logRTErrorF :: String -> a
-logRTErrorF msg =
+rtMessage :: String -> String
+rtMessage msg =
   let header = "Firelink Internal Runtime Error:\t" ++ msg ++ "\n"
       mid = "\tPlease, open a new issue on Github attaching the .souls file you just used\n"
       end = "\tGithub Issue Tracker: https://github.com/aitorres/firelink/issues"
       fullMsg = header ++ mid ++ end
-  in error fullMsg
+  in fullMsg
+
+logRTError :: String -> ST.ParserMonad (a)
+logRTError msg = error $ rtMessage msg
 
 }

--- a/src/frontend/Parser.y
+++ b/src/frontend/Parser.y
@@ -693,10 +693,9 @@ addIdToSymTable mi d@(c, gId@(G.Id tk@(T.Token {T.aToken=at, T.cleanedString=idN
         }
       entry <- checkIdAvailability gId
       case (entry, maybeExp) of
-        (Nothing, _) -> return ()
-        (_, Nothing) -> return ()
         (Just en, Just exp) -> do
           checkTypeOfAssignment en exp (G.expTok exp)
+        _ -> return ()
 
     -- The name does exists on the table, we just add it depending on the scope
     Just entry -> do
@@ -1201,6 +1200,7 @@ checkAccess e (G.Id tk'@T.Token{T.cleanedString=i} _) tk = do
     T.UnionT scope properties -> checkProperty properties scope
     T.TypeError -> return defaultReturn
     _ -> do
+      RWS.liftIO $ print $ show t
       logSemError "Left side of access is not a record nor union" tk
       return defaultReturn
   where

--- a/src/frontend/Tokens.hs
+++ b/src/frontend/Tokens.hs
@@ -121,6 +121,7 @@ instance Show AbstractToken where
     show TkArray = U.green ++ U.bold ++ U.underline
     show TkSet = U.green ++ U.bold ++ U.underline
     show TkRecord = U.green ++ U.bold ++ U.underline
+    show TkUnionStruct = U.green ++ U.bold ++ U.underline
     show TkAlias = U.cyan ++ U.bold
     show TkAliasListBegin = U.magenta ++ U.bold
     show TkAliasListEnd = U.magenta ++ U.bold

--- a/src/frontend/TypeChecking.hs
+++ b/src/frontend/TypeChecking.hs
@@ -14,6 +14,7 @@ data Type
   | CharT
   | StringT
   | VoidT
+  | StructLitT
   | ArrayT Type
   | SetT Type
   | RecordT Int [PropType]
@@ -34,6 +35,7 @@ instance Show Type where
   show CharT = "sign"
   show StringT = "miracle"
   show VoidT = "abyss"
+  show StructLitT = "struct literal"
   show (ArrayT t) = "chest of type " ++ show t
   show (SetT t) = "armor of type " ++ show t
   show (RecordT _ ps) = "link with elements " ++ formattedElements
@@ -59,6 +61,7 @@ instance Eq Type where
   FloatT == FloatT = True
   CharT == CharT = True
   StringT == StringT = True
+  StructLitT == StructLitT = True
   ArrayT t == ArrayT t' = t == t'
   SetT t == SetT t' = t == t'
   UnionT s pt == UnionT s' pt' = sort pt == sort pt' && s == s'

--- a/test/Semantic/RecordLikeTypesDeclSpec.hs
+++ b/test/Semantic/RecordLikeTypesDeclSpec.hs
@@ -249,3 +249,59 @@ spec = do
             \you died\n\
 
             \farewell ashen one" `U.shouldErrorOn` ("~>", 12, 51)
+        it "accepts valid assigment of a struct literal for record" $
+            U.shouldNotError "hello ashen one\n\
+
+            \traveling somewhere\n\
+
+            \with\n\
+            \   var x of type bezel { a of type humanity, b of type hollow } \n\
+            \in your inventory\n\
+
+            \   x <<= { a <<= 1, b <<= 5.6 } \n\
+
+            \you died\n\
+
+            \farewell ashen one"
+        it "accepts valid assigment of a struct literal for union" $
+            U.shouldNotError "hello ashen one\n\
+
+            \traveling somewhere\n\
+
+            \with\n\
+            \   var x of type link { a of type humanity, b of type hollow } \n\
+            \in your inventory\n\
+
+            \   x <<= { a <<= 1 } \n\
+
+            \you died\n\
+
+            \farewell ashen one"
+        it "accepts valid initialization on declaration of a struct literal for record" $
+            U.shouldNotError "hello ashen one\n\
+
+            \traveling somewhere\n\
+
+            \with\n\
+            \   var x of type bezel { a of type humanity, b of type hollow } <<= { a <<= 1, b <<= 5.4 } \n\
+            \in your inventory\n\
+
+            \   go back \n\
+
+            \you died\n\
+
+            \farewell ashen one"
+        it "accepts valid initialization on declaration of a struct literal for union" $
+            U.shouldNotError "hello ashen one\n\
+
+            \traveling somewhere\n\
+
+            \with\n\
+            \   var x of type link { a of type humanity, b of type hollow } <<= { b <<= 5.4 } \n\
+            \in your inventory\n\
+
+            \   go back \n\
+
+            \you died\n\
+
+            \farewell ashen one"

--- a/test/TypeChecking/AccessSpec.hs
+++ b/test/TypeChecking/AccessSpec.hs
@@ -1,0 +1,81 @@
+module AccessSpec where
+
+import Test.Hspec
+import qualified TestUtils as U
+
+baseProgram :: String -> String -> String -> String
+baseProgram t a e = "hello ashen one\n\
+
+\traveling somewhere \n\
+\with\n\
+\   var x of type " ++ t ++ "\n\
+\in your inventory\n\
+\   x~>" ++ a ++ " <<= " ++ e ++ "\n\
+\you died\n\
+
+\farewell ashen one"
+
+baseProgramWithAliases :: String -> String -> String -> String -> String
+baseProgramWithAliases aliases t a e = "hello ashen one\n\
+
+\requiring help of \n\
+\" ++ aliases ++ "\n\
+\help received\n\
+
+\traveling somewhere \n\
+\with\n\
+\   var x of type " ++ t ++ "\n\
+\in your inventory\n\
+\   x~>" ++ a ++ " <<= " ++ e ++ "\n\
+\you died\n\
+
+\farewell ashen one"
+
+spec :: Spec
+spec =
+  describe "`accesses`" $ do
+    it "should accept an access for an explicit union" $
+      U.shouldNotError $ baseProgram "link { a of type humanity }" "a" "3"
+
+    it "should accept an access for an explicit union with multiple props" $
+      U.shouldNotError $ baseProgram "link { a of type humanity, b of type hollow }" "b" "3.5"
+
+    it "should accept an access for an explicit record" $
+      U.shouldNotError $ baseProgram "bezel { a of type humanity }" "a" "3"
+
+    it "should accept an access for an explicit record with multiple props" $
+      U.shouldNotError $ baseProgram "bezel { a of type humanity, b of type hollow }" "b" "3.5"
+
+    it "should reject an access for a non-struct type" $
+      baseProgram "hollow" "a" "3" `U.shouldErrorOn` ("<<=", 6, 5)
+
+    it "should reject an access for an explicit union with an incorrect prop" $
+      baseProgram "link { a of type humanity }" "b" "3" `U.shouldErrorOn` ("<<=", 6, 5)
+
+    it "should reject an access for an explicit union with an incorrect type" $
+      baseProgram "link { a of type humanity }" "a" "3.5" `U.shouldErrorOn` ("<<=", 6, 9)
+
+    it "should reject an access for an explicit record with an incorrect prop" $
+      baseProgram "bezel { a of type humanity }" "b" "3" `U.shouldErrorOn` ("<<=", 6, 5)
+
+    it "should reject an access for an explicit record with an incorrect type" $
+      baseProgram "bezel { a of type humanity }" "a" "3.5" `U.shouldErrorOn` ("<<=", 6, 9)
+
+    it "should accept an access for an aliased union" $
+        U.shouldNotError $ baseProgramWithAliases "knight lizy link { a of type humanity }" "lizy" "a" "3"
+
+    it "should accept an access for an aliased record" $
+        U.shouldNotError $ baseProgramWithAliases "knight bezy bezel { a of type humanity }" "bezy" "a" "3"
+
+    it "should reject an access for an aliased type other than a struct" $
+        baseProgramWithAliases "knight bezy hollow" "bezy" "a" "3" `U.shouldErrorOn` ("<<=", 9, 5)
+
+    it "should accept an access for an indirectly aliased union" $
+        U.shouldNotError $ baseProgramWithAliases "knight lizy link { a of type humanity }, knight lizzy lizy" "lizzy" "a" "3"
+
+    it "should accept an access for an indirectly aliased record" $
+        U.shouldNotError $ baseProgramWithAliases "knight bezy bezel { a of type humanity }, knight bezzy bezy" "bezzy" "a" "3"
+
+    it "should reject an access for an indirectly aliased type other than a struct" $
+        baseProgramWithAliases "knight bezy humanity, knight bezzy bezy" "bezzy" "a" "3" `U.shouldErrorOn` ("<<=", 9, 5)
+

--- a/test/TypeChecking/StructsSpec.hs
+++ b/test/TypeChecking/StructsSpec.hs
@@ -1,0 +1,48 @@
+module StructsSpec where
+
+import Test.Hspec
+import qualified TestUtils as U
+
+baseProgram :: String -> String -> String
+baseProgram t e = "hello ashen one\n\
+
+\traveling somewhere \n\
+\with\n\
+\   var x of type " ++ t ++ "\n\
+\in your inventory\n\
+\   x <<= " ++ e ++ "\n\
+\you died\n\
+
+\farewell ashen one"
+
+spec :: Spec
+spec =
+  describe "`struct-like types`" $ do
+    it "should reject invalid type assignment on a record" $
+      baseProgram "bezel { a of type humanity }" "3" `U.shouldErrorOn` ("<<=", 6, 6)
+
+    it "should reject invalid type assignment on a union" $
+      baseProgram "link { a of type humanity }" "3" `U.shouldErrorOn` ("<<=", 6, 6)
+
+    it "should reject invalid type assignment on a record" $
+      baseProgram "bezel { a of type humanity }" "{ a <<= 3.6 }" `U.shouldErrorOn` ("<<=", 6, 6)
+
+    it "should reject invalid type assignment on a union" $
+      baseProgram "link { a of type humanity }" "{ a <<= 3.6 }" `U.shouldErrorOn` ("<<=", 6, 6)
+
+    it "should reject invalid name assignment on a record" $
+      baseProgram "bezel { a of type humanity }" "{ b <<= 3 }" `U.shouldErrorOn` ("<<=", 6, 6)
+
+    it "should reject invalid name assignment on a union" $
+      baseProgram "link { a of type humanity }" "{ b <<= 3 }" `U.shouldErrorOn` ("<<=", 6, 6)
+
+    it "should reject assignments of several properties on a union" $
+      baseProgram "link { a of type humanity, b of type hollow }" "{ a <<= 2, b <<= 3.5 }" `U.shouldErrorOn` ("<<=", 6, 6)
+
+    it "should reject assignments of less properties on a record" $
+      baseProgram "bezel { a of type humanity, b of type hollow }" "{ a <<= 2 }" `U.shouldErrorOn` ("<<=", 6, 6)
+
+    it "should reject assignments of more properties on a record" $
+      baseProgram "bezel { a of type humanity, b of type hollow }" "{ a <<= 2, b <<= 4.5, c <<= 12141 }" `U.shouldErrorOn` ("<<=", 6, 6)
+
+


### PR DESCRIPTION
This PR introduces literals for records & unions, among other changes and fixes. Particularly:

- Spec changes to list info on valid record/union literal usage
- Add record/union literals to the parser
- Proper type-checking for record/union literals
- Fixes on record/union access type-checking
- Fixes on directly & indirectly aliased record/union types type-checking
- Add unit tests for all the mentioned changes

Closes #44 