### PR TITLE
Feature: add offset and width

### DIFF
--- a/src/FireLink/FrontEnd/Parser.y
+++ b/src/FireLink/FrontEnd/Parser.y
@@ -475,12 +475,15 @@ CODEBLOCK :: { G.CodeBlock }
 INSTBEGIN :: { T.Token }
 INSTBEGIN : instructionsBegin                                           {% do
                                                                             ST.enterScope
+                                                                            nextOffset <- ST.getNextOffset
+                                                                            ST.pushOffset nextOffset
                                                                             st <- RWS.get
                                                                             return $1 }
 
 INSTEND :: { Maybe G.RecoverableError }
   : instructionsEnd                                                     {% do
                                                                              ST.exitScope
+                                                                             ST.popOffset
                                                                              return Nothing }
   | error                                                               { Just G.MissingInstructionListEnd }
 

--- a/src/FireLink/FrontEnd/Parser.y
+++ b/src/FireLink/FrontEnd/Parser.y
@@ -811,8 +811,11 @@ assignOffsetAndInsert entry = do
         Just typeEntry -> do
           nextOffset <- ST.getNextOffset
           let ST.Width width = ST.findWidth typeEntry
-          ST.updateOffsetWithWidth width
-          return $ (ST.Offset nextOffset) : extras
+          let remainingOffset = ST.wordSize - (nextOffset `mod` ST.wordSize)
+          let finalOffset = if width <= remainingOffset then nextOffset
+                            else nextOffset + remainingOffset
+          ST.putNextOffset $ finalOffset + width
+          return $ (ST.Offset finalOffset) : extras
     else return extras
   ST.addEntry entry{ST.extra=finalExtras}
   where

--- a/src/FireLink/FrontEnd/Parser.y
+++ b/src/FireLink/FrontEnd/Parser.y
@@ -217,7 +217,14 @@ ALIASADD :: { () }
                                                                             return () }
 
 ALIAS :: { NameDeclaration }
-  : alias ID TYPE                                                       { (ST.Type, $2, [$3]) }
+  : alias ID TYPE                                                       {% do
+                                                                            let (ST.Simple i) = $3
+                                                                            maybeEntry <- ST.dictLookup i
+                                                                            let t = $3
+                                                                            let extras = (case maybeEntry of
+                                                                                            Nothing -> [t]
+                                                                                            Just entry -> [t, ST.findWidth $ ST.extra entry])
+                                                                            return (ST.Type, $2, extras) }
 
 LVALUE :: { G.Expr }
   : ID                                                                  {% do
@@ -370,6 +377,7 @@ PARTYPE :: { ST.Category }
   : parVal                                                              { ST.ValueParam }
   | parRef                                                              { ST.RefParam }
 
+{- TYPE always returns "ST.Simple String" -}
 TYPE :: { ST.Extra }
   : ID                                                                  {% do
                                                                           let G.Id t _ = $1

--- a/src/FireLink/FrontEnd/SymTable.hs
+++ b/src/FireLink/FrontEnd/SymTable.hs
@@ -292,19 +292,6 @@ popOffset = do
     st@SymTable{stOffsetStack = _ : offsets} <- RWS.get
     RWS.put st{stOffsetStack = offsets}
 
--- This function tries to increase offset as better
--- as it can
-updateOffsetWithWidth :: Int -> ParserMonad ()
-updateOffsetWithWidth width = do
-    currOffset <- getNextOffset
-    let remainingOffset = wordSize - (currOffset `mod` wordSize)
-    if width <= remainingOffset then
-        putNextOffset $ currOffset + width
-    else
-        putNextOffset $
-            (currOffset + remainingOffset) + -- to align to wordSize
-            width
-
 smallHumanity :: String
 smallHumanity = "small humanity"
 humanity :: String

--- a/src/FireLink/FrontEnd/SymTable.hs
+++ b/src/FireLink/FrontEnd/SymTable.hs
@@ -58,11 +58,18 @@ data Extra
 
     -- Width of type. It is not world-aligned
     | Width Int
+
+    -- Unique identifier for each union-attribute
+    | UnionAttrId Int
     deriving Show
 
 isWidthExtra :: Extra -> Bool
 isWidthExtra Width{} = True
 isWidthExtra _ = False
+
+isUnionAttrId :: Extra -> Bool
+isUnionAttrId UnionAttrId{} = True
+isUnionAttrId _ = False
 
 isFieldsExtra :: Extra -> Bool
 isFieldsExtra (Fields _ _) = True
@@ -129,7 +136,9 @@ data SymTable = SymTable
       stVisitedMethod :: !(Maybe String), -- ^ List of currently visited method
       stNextAnonymousAlias :: !Int, -- ^ Next anonymous alias to be used with anonymous data types
       stNextParamId :: !Int, -- ^ Used to generate next parameter id (for ordering) in functions
-      stOffsetStack :: ![Int] -- ^ Used to carry offset in scopes
+      stOffsetStack :: ![Int], -- ^ Used to carry offset in scopes
+      stUnionAttrIdStack :: ![Int] -- ^ Used to assign an unique identifier to each union-attr.
+                                   -- we need a stack because we can have nested unions
     }
     deriving Show
 
@@ -292,6 +301,22 @@ popOffset = do
     st@SymTable{stOffsetStack = _ : offsets} <- RWS.get
     RWS.put st{stOffsetStack = offsets}
 
+newUnion :: ParserMonad ()
+newUnion = do
+    st@SymTable{stUnionAttrIdStack = unions} <- RWS.get
+    RWS.put st{stUnionAttrIdStack = 0 : unions}
+
+genNextUnion :: ParserMonad Int
+genNextUnion = do
+    st@SymTable{stUnionAttrIdStack = union : unions} <- RWS.get
+    RWS.put st{stUnionAttrIdStack = (union + 1) : unions}
+    return union
+
+popUnion :: ParserMonad ()
+popUnion = do
+    st@SymTable{stUnionAttrIdStack = _ : unions} <- RWS.get
+    RWS.put st{stUnionAttrIdStack = unions}
+
 smallHumanity :: String
 smallHumanity = "small humanity"
 humanity :: String
@@ -323,7 +348,7 @@ wordSize :: Int
 wordSize = 4
 
 initialState :: SymTable
-initialState = SymTable (Map.fromList l) [1, 0] 1 [] [] [] Nothing 0 0 [0]
+initialState = SymTable (Map.fromList l) [1, 0] 1 [] [] [] Nothing 0 0 [0] []
     where l = [(smallHumanity, [DictionaryEntry smallHumanity Type 0 Nothing [Width 2]])
             , (humanity, [DictionaryEntry humanity Type 0 Nothing [Width 4]])
             , (hollow, [DictionaryEntry hollow Type 0 Nothing [Width 8]])

--- a/src/FireLink/FrontEnd/SymTable.hs
+++ b/src/FireLink/FrontEnd/SymTable.hs
@@ -60,6 +60,10 @@ data Extra
     | Width Int
     deriving Show
 
+isWidthExtra :: Extra -> Bool
+isWidthExtra Width{} = True
+isWidthExtra _ = False
+
 isFieldsExtra :: Extra -> Bool
 isFieldsExtra (Fields _ _) = True
 isFieldsExtra _            = False
@@ -70,6 +74,11 @@ isArgPosition _             = False
 
 findArgPosition :: [Extra] -> Extra
 findArgPosition = head . filter isArgPosition
+
+findWidth :: [Extra] -> Extra
+findWidth extras = let widthExtras = filter isWidthExtra extras in
+    if null widthExtras then error "Width extra not found"
+    else head widthExtras
 
 findFieldsExtra :: Extra -> Maybe Extra
 findFieldsExtra a@Fields{}          = Just a

--- a/src/FireLink/FrontEnd/SymTable.hs
+++ b/src/FireLink/FrontEnd/SymTable.hs
@@ -80,7 +80,10 @@ isArgPosition ArgPosition{} = True
 isArgPosition _             = False
 
 findArgPosition :: [Extra] -> Extra
-findArgPosition = head . filter isArgPosition
+findArgPosition extras = let filtered = filter isArgPosition extras in
+    if null filtered then error "findArgPosition didn't found an ArgPosition"
+    else head filtered
+
 
 findWidth :: DictionaryEntry -> Extra
 findWidth entry = f $ extra entry
@@ -348,7 +351,7 @@ wordSize :: Int
 wordSize = 4
 
 initialState :: SymTable
-initialState = SymTable (Map.fromList l) [1, 0] 1 [] [] [] Nothing 0 0 [0] []
+initialState = SymTable (Map.fromList l) [1, 0] 1 [] [] [] Nothing 0 0 [] []
     where l = [(smallHumanity, [DictionaryEntry smallHumanity Type 0 Nothing [Width 2]])
             , (humanity, [DictionaryEntry humanity Type 0 Nothing [Width 4]])
             , (hollow, [DictionaryEntry hollow Type 0 Nothing [Width 8]])

--- a/test/Semantic/OffsetSpec.hs
+++ b/test/Semantic/OffsetSpec.hs
@@ -34,9 +34,8 @@ spec :: Spec
 spec =
     describe "Offset calculation" $ do
         it "calculates offset for the first variable in the list" $
-            1 `shouldBe` 1
-        --     testOffset "var x of type humanity" [("x", 0)]
-        -- it "calculates offset for second variable in the list when first variable's type width is multiple of `wordsize`" $
-        --     testOffset "var x of type humanity, var y of type humanity" [("x", 0), ("y", 4)]
-        -- it "calculates offset for second variable in the list when first variable's type width is not a multiple of `wordSize`" $
-        --     testOffset "var x of type sign, var y of type humanity" [("x", 0), ("y", 4)]
+            testOffset "var x of type humanity" [("x", 0)]
+        it "calculates offset for second variable in the list when first variable's type width is multiple of `wordsize`" $
+            testOffset "var x of type humanity, var y of type humanity" [("x", 0), ("y", 4)]
+        it "calculates offset for second variable in the list when first variable's type width is not a multiple of `wordSize`" $
+            testOffset "var x of type sign, var y of type humanity" [("x", 0), ("y", 4)]

--- a/test/Semantic/OffsetSpec.hs
+++ b/test/Semantic/OffsetSpec.hs
@@ -50,6 +50,12 @@ spec =
             \   x3 of type sign\
             \},\
             \var x4 of type sign" [("x1", 0), ("x2", 0), ("x3", 4), ("x4", 5)]
+        it "calculates offset for links" $
+            testOffset "\
+            \var x1 of type link {\
+            \   x2 of type humanity,\
+            \   x3 of type sign\
+            \}" [("x1", 0), ("x2", 4), ("x3", 4)]
         it "takes advantage of scopes to achieve a better use of offsets" $
             testProgram "hello ashen one\n\
             \ traveling somewhere \

--- a/test/Semantic/OffsetSpec.hs
+++ b/test/Semantic/OffsetSpec.hs
@@ -14,7 +14,7 @@ testOffset programFragment testItems = do
             let chain = filter (\d -> ST.name d == varName) $ ST.findChain varName dictionary
             let dictEntry = head chain
             let ST.Offset actualOffset = U.extractOffsetFromExtra $ ST.extra dictEntry
-            expectedOffset `shouldBe` actualOffset
+            actualOffset `shouldBe` expectedOffset
         getDictionary :: String -> IO ST.Dictionary
         getDictionary program = do
             ST.SymTable {ST.stDict = dict} <- U.extractDictionary program

--- a/test/Semantic/OffsetSpec.hs
+++ b/test/Semantic/OffsetSpec.hs
@@ -33,9 +33,9 @@ testOffset programFragment testItems = do
 spec :: Spec
 spec =
     describe "Offset calculation" $ do
-        it "calculates offset for the first variable in the list" $
-            testOffset "var x of type humanity" [("x", 0)]
-        it "calculates offset for second variable in the list when first variable's type width is multiple of `wordsize`" $
-            testOffset "var x of type humanity, var y of type humanity" [("x", 0), ("y", 4)]
-        it "calculates offset for second variable in the list when first variable's type width is not a multiple of `wordSize`" $
-            testOffset "var x of type sign, var y of type humanity" [("x", 0), ("y", 4)]
+        it "calculates offset for the first variable in the list" $ 1 `shouldBe` 1
+        --     testOffset "var x of type humanity" [("x", 0)]
+        -- it "calculates offset for second variable in the list when first variable's type width is multiple of `wordsize`" $
+        --     testOffset "var x of type humanity, var y of type humanity" [("x", 0), ("y", 4)]
+        -- it "calculates offset for second variable in the list when first variable's type width is not a multiple of `wordSize`" $
+        --     testOffset "var x of type sign, var y of type humanity" [("x", 0), ("y", 4)]

--- a/test/Semantic/OffsetSpec.hs
+++ b/test/Semantic/OffsetSpec.hs
@@ -33,9 +33,9 @@ testOffset programFragment testItems = do
 spec :: Spec
 spec =
     describe "Offset calculation" $ do
-        it "calculates offset for the first variable in the list" $ 1 `shouldBe` 1
-        --     testOffset "var x of type humanity" [("x", 0)]
-        -- it "calculates offset for second variable in the list when first variable's type width is multiple of `wordsize`" $
-        --     testOffset "var x of type humanity, var y of type humanity" [("x", 0), ("y", 4)]
-        -- it "calculates offset for second variable in the list when first variable's type width is not a multiple of `wordSize`" $
-        --     testOffset "var x of type sign, var y of type humanity" [("x", 0), ("y", 4)]
+        it "calculates offset for the first variable in the list" $
+            testOffset "var x of type humanity" [("x", 0)]
+        it "calculates offset for second variable in the list when first variable's type width is multiple of `wordsize`" $
+            testOffset "var x of type humanity, var y of type humanity" [("x", 0), ("y", 4)]
+        it "calculates offset for second variable in the list when first variable's type width is not a multiple of `wordSize`" $
+            testOffset "var x of type sign, var y of type humanity" [("x", 0), ("y", 4)]

--- a/test/Semantic/OffsetSpec.hs
+++ b/test/Semantic/OffsetSpec.hs
@@ -9,16 +9,6 @@ testOffset programFragment testItems = do
     dictionary <- getDictionary $ baseProgram programFragment
     mapM_ (test dictionary) testItems
     where
-        test :: ST.Dictionary -> (String, Int) -> IO ()
-        test dictionary (varName, expectedOffset) = do
-            let chain = filter (\d -> ST.name d == varName) $ ST.findChain varName dictionary
-            let dictEntry = head chain
-            let ST.Offset actualOffset = U.extractOffsetFromExtra $ ST.extra dictEntry
-            actualOffset `shouldBe` expectedOffset
-        getDictionary :: String -> IO ST.Dictionary
-        getDictionary program = do
-            ST.SymTable {ST.stDict = dict} <- U.extractDictionary program
-            return dict
         baseProgram :: String -> String
         baseProgram s = "hello ashen one\n\
 
@@ -30,6 +20,17 @@ testOffset programFragment testItems = do
                     \ you died \
                     \ farewell ashen one"
 
+test :: ST.Dictionary -> (String, Int) -> IO ()
+test dictionary (varName, expectedOffset) = do
+    let chain = filter (\d -> ST.name d == varName) $ ST.findChain varName dictionary
+    let dictEntry = head chain
+    let ST.Offset actualOffset = U.extractOffsetFromExtra $ ST.extra dictEntry
+    actualOffset `shouldBe` expectedOffset
+getDictionary :: String -> IO ST.Dictionary
+getDictionary program = do
+    ST.SymTable {ST.stDict = dict} <- U.extractDictionary program
+    return dict
+
 spec :: Spec
 spec =
     describe "Offset calculation" $ do
@@ -39,3 +40,44 @@ spec =
             testOffset "var x of type humanity, var y of type humanity" [("x", 0), ("y", 4)]
         it "calculates offset for second variable in the list when first variable's type width is not a multiple of `wordSize`" $
             testOffset "var x of type sign, var y of type humanity" [("x", 0), ("y", 4)]
+        it "calculates offset for variables with mixed data types" $
+            testOffset "\
+            \var x1 of type bezel {\
+            \   x2 of type humanity,\
+            \   x3 of type sign\
+            \},\
+            \var x4 of type sign" [("x1", 0), ("x2", 0), ("x3", 4), ("x4", 5)]
+        it "takes advantage of scopes to achieve a better use of offsets" $ do
+            let program = "hello ashen one\n\
+            \ traveling somewhere \
+            \ with \
+            \   var x of type humanity\
+            \ in your inventory \
+            \ while the lit covenant is active:\
+            \   traveling somewhere\
+            \   with\
+            \       var y of type humanity\
+            \   in your inventory\
+            \       while the lit covenant is active:\
+            \         traveling somewhere\
+            \         with\
+            \             var w of type humanity\
+            \         in your inventory\
+            \             go back\
+            \         you died \
+            \       covenant left\
+            \   you died \
+            \ covenant left \\ \
+            \ while the lit covenant is active:\
+            \   traveling somewhere\
+            \   with\
+            \       var z of type humanity\
+            \   in your inventory\
+            \       go back\
+            \   you died \
+            \ covenant left\
+            \ you died \
+
+            \ farewell ashen one"
+            dictionary <- getDictionary program
+            mapM_ (test dictionary) [("x", 0), ("y", 4), ("z", 4), ("w", 8)]

--- a/test/Semantic/RecordLikeTypesDeclSpec.hs
+++ b/test/Semantic/RecordLikeTypesDeclSpec.hs
@@ -61,12 +61,12 @@ spec = do
                 , ST.entryType=Just "link"} U.extractFieldsFromExtra (\(ST.Fields ST.Union 2) -> True)
             U.testEntry dict varEntry
                 { ST.name="y"
-                , ST.category=ST.RecordItem
+                , ST.category=ST.UnionItem
                 , ST.scope=2
                 , ST.entryType=Just "humanity"} U.extractSimpleFromExtra (\(ST.Simple "humanity") -> True)
             U.testEntry dict varEntry
                 { ST.name="z"
-                , ST.category=ST.RecordItem
+                , ST.category=ST.UnionItem
                 , ST.scope=2
                 , ST.entryType=Just "sign"} U.extractSimpleFromExtra (\(ST.Simple "sign") -> True)
         it "allows to declare record and simple var (in that order)" $ do

--- a/test/Semantic/WidthSpec.hs
+++ b/test/Semantic/WidthSpec.hs
@@ -43,15 +43,15 @@ spec = do
             testWidth "hollow" 8
     describe "Width calculation for composite data types" $ do
         it "calculates width for chests" $
-            testWidth "<4>-chest of type humanity" 4
+            testWidth "<4>-chest of type humanity" 8
         it "calculates width for chests of chests" $
-            testWidth "<4>-chest of type <4>-chest of type humanity" 4
+            testWidth "<4>-chest of type <4>-chest of type humanity" 8
         it "calculates width for sets" $
             testWidth "armor of type humanity" 4
         it "calculates width for sets of sets" $
             testWidth "armor of type armor of type humanity" 4
         it "calculates width for strings" $
-            testWidth "<4>-miracle" 4
+            testWidth "<4>-miracle" 8
         it "calculates width for pointers" $
             testWidth "arrow to hollow" 4
     describe "Width calculation for record data types" $ do

--- a/test/Semantic/WidthSpec.hs
+++ b/test/Semantic/WidthSpec.hs
@@ -4,6 +4,11 @@ import qualified FireLink.FrontEnd.SymTable   as ST
 import           Test.Hspec
 import qualified TestUtils  as U
 
+getDictionary :: String -> IO ST.Dictionary
+getDictionary program = do
+    ST.SymTable {ST.stDict = dict} <- U.extractDictionary program
+    return dict
+
 testWidth :: String -> Int -> IO ()
 testWidth programFragment expectedWidth = do
     dictionary <- getDictionary $ baseProgram programFragment
@@ -13,10 +18,6 @@ testWidth programFragment expectedWidth = do
     where
         varName :: String
         varName = "x"
-        getDictionary :: String -> IO ST.Dictionary
-        getDictionary program = do
-            ST.SymTable {ST.stDict = dict} <- U.extractDictionary program
-            return dict
         baseProgram :: String -> String
         baseProgram s = "hello ashen one\n\
                     \ requiring help of \n\
@@ -65,3 +66,46 @@ spec = do
             testWidth "bezel { y of type sign, x of type humanity }" 8
             testWidth "bezel { y of type sign, y of type bonfire, x of type humanity }" 8
             testWidth "bezel { x of type humanity, y of type sign, z of type bonfire" 6
+            testWidth "bezel {\
+                \   x of type bezel { x of type humanity, z of type humanity },\
+                \   y of type <4>-chest of type humanity\
+                \}" 16
+    describe "Width calculation for union data types" $ do
+        it "calculate width of just 1-attribute record" $
+            testWidth "link { x of type humanity }" 8
+        it "calculate width of 2+ attribute records" $ do
+            testWidth "link { x of type humanity, y of type humanity }" 8
+            testWidth "link { x of type sign, y of type bonfire, z of type small humanity }" 8
+            testWidth "\
+            \ link {\
+            \   x of type bezel {\
+            \       x of type humanity,\
+            \       y of type hollow\
+            \   },\
+            \   y of type bezel { x of type bonfire, z of type sign }\
+            \ }" 16
+        it "assigns a number on each attribute for is active impl" $ do
+            let program = "hello ashen one\n\
+                    \ requiring help of \n\
+                    \   knight xx link {\
+                    \       x of type humanity,\
+                    \       y of type link {\
+                    \           a of type humanity,\
+                    \           b of type hollow\
+                    \       },\
+                    \       z of type bonfire\
+                    \   }\
+                    \ help received \
+
+                    \ traveling somewhere \
+                    \ with orange saponite say @hello world@ \
+                    \ you died \
+                    \ farewell ashen one"
+            (_, ST.SymTable {ST.stDict=dict}, _) <- U.extractSymTable program
+            mapM_ (test dict) [("x", 0), ("y", 1), ("z", 2), ("a", 0), ("b", 0)]
+            where
+                test :: ST.Dictionary -> (String, Int) -> IO ()
+                test dictionary (varName, unionAttrId) = do
+                    let chain = filter (\d -> ST.name d == varName) $ ST.findChain varName dictionary
+                    let ST.UnionAttrId i = U.extractUnionAttrIdFromExtra $ ST.extra $ head chain
+                    i `shouldBe` unionAttrId

--- a/test/Semantic/WidthSpec.hs
+++ b/test/Semantic/WidthSpec.hs
@@ -31,36 +31,36 @@ testWidth programFragment expectedWidth = do
 spec :: Spec
 spec = do
     describe "Width calculation for simple data types" $ do
-        it "calculates width for the humanity" $ 1 `shouldBe` 1
-    --         testWidth "humanity" 4
-    --     it "calculates width for the sign" $
-    --         testWidth "sign" 1
-    --     it "calculates width for the bonfire" $
-    --         testWidth "bonfire" 1
-    --     it "calculates width for the small-humanity" $
-    --         testWidth "small humanity" 2
-    --     it "calculates width for the floats" $
-    --         testWidth "hollow" 8
-    -- describe "Width calculation for composite data types" $ do
-    --     it "calculates width for chests" $
-    --         testWidth "<4>-chest of type humanity" 4
-    --     it "calculates width for chests of chests" $
-    --         testWidth "<4>-chest of type <4>-chest of type humanity" 4
-    --     it "calculates width for sets" $
-    --         testWidth "armor of type humanity" 4
-    --     it "calculates width for sets of sets" $
-    --         testWidth "armor of type armor of type humanity" 4
-    --     it "calculates width for strings" $
-    --         testWidth "<4>-miracle" 4
-    --     it "calculates width for pointers" $
-    --         testWidth "arrow to hollow" 4
-    -- describe "Width calculation for record data types" $ do
-    --     it "calculate width of just 1-attribute record" $
-    --         testWidth "bezel { x of type humanity }" 4
-    --     it "calculate width of 2 attribute records" $
-    --         testWidth "bezel { x of type humanity, y of type humanity }" 4
-    --     it "tries to pack attributes as much as it can without breaking words" $
-    --         testWidth "bezel { x of type humanity, y of type sign }" 5
-    --     it "go to next multiple of 4 if a new attribute is broken" $ do
-    --         testWidth "bezel { y of type sign, x of type humanity }" 8
-    --         testWidth "bezel { y of type sign, y of type bonfire, x of type humanity }" 8
+        it "calculates width for the humanity" $
+            testWidth "humanity" 4
+        it "calculates width for the sign" $
+            testWidth "sign" 1
+        it "calculates width for the bonfire" $
+            testWidth "bonfire" 1
+        it "calculates width for the small-humanity" $
+            testWidth "small humanity" 2
+        it "calculates width for the floats" $
+            testWidth "hollow" 8
+    describe "Width calculation for composite data types" $ do
+        it "calculates width for chests" $
+            testWidth "<4>-chest of type humanity" 4
+        it "calculates width for chests of chests" $
+            testWidth "<4>-chest of type <4>-chest of type humanity" 4
+        it "calculates width for sets" $
+            testWidth "armor of type humanity" 4
+        it "calculates width for sets of sets" $
+            testWidth "armor of type armor of type humanity" 4
+        it "calculates width for strings" $
+            testWidth "<4>-miracle" 4
+        it "calculates width for pointers" $
+            testWidth "arrow to hollow" 4
+    describe "Width calculation for record data types" $ do
+        it "calculate width of just 1-attribute record" $
+            testWidth "bezel { x of type humanity }" 4
+        it "calculate width of 2 attribute records" $
+            testWidth "bezel { x of type humanity, y of type humanity }" 4
+        it "tries to pack attributes as much as it can without breaking words" $
+            testWidth "bezel { x of type humanity, y of type sign }" 5
+        it "go to next multiple of 4 if a new attribute is broken" $ do
+            testWidth "bezel { y of type sign, x of type humanity }" 8
+            testWidth "bezel { y of type sign, y of type bonfire, x of type humanity }" 8

--- a/test/Semantic/WidthSpec.hs
+++ b/test/Semantic/WidthSpec.hs
@@ -75,7 +75,7 @@ spec = do
             testWidth "link { x of type humanity }" 8
         it "calculate width of 2+ attribute records" $ do
             testWidth "link { x of type humanity, y of type humanity }" 8
-            testWidth "link { x of type sign, y of type bonfire, z of type small humanity }" 8
+            testWidth "link { x of type sign, y of type bonfire, z of type small humanity }" 6
             testWidth "\
             \ link {\
             \   x of type bezel {\

--- a/test/Semantic/WidthSpec.hs
+++ b/test/Semantic/WidthSpec.hs
@@ -71,7 +71,7 @@ spec = do
                 \   y of type <4>-chest of type humanity\
                 \}" 16
     describe "Width calculation for union data types" $ do
-        it "calculate width of just 1-attribute record" $
+        it "calculate width of just 1-attribute union" $
             testWidth "link { x of type humanity }" 8
         it "calculate width of 2+ attribute records" $ do
             testWidth "link { x of type humanity, y of type humanity }" 8
@@ -102,7 +102,7 @@ spec = do
                     \ you died \
                     \ farewell ashen one"
             (_, ST.SymTable {ST.stDict=dict}, _) <- U.extractSymTable program
-            mapM_ (test dict) [("x", 0), ("y", 1), ("z", 2), ("a", 0), ("b", 0)]
+            mapM_ (test dict) [("x", 0), ("y", 1), ("z", 2), ("a", 0), ("b", 1)]
             where
                 test :: ST.Dictionary -> (String, Int) -> IO ()
                 test dictionary (varName, unionAttrId) = do

--- a/test/Semantic/WidthSpec.hs
+++ b/test/Semantic/WidthSpec.hs
@@ -58,9 +58,10 @@ spec = do
         it "calculate width of just 1-attribute record" $
             testWidth "bezel { x of type humanity }" 4
         it "calculate width of 2 attribute records" $
-            testWidth "bezel { x of type humanity, y of type humanity }" 4
+            testWidth "bezel { x of type humanity, y of type humanity }" 8
         it "tries to pack attributes as much as it can without breaking words" $
             testWidth "bezel { x of type humanity, y of type sign }" 5
         it "go to next multiple of 4 if a new attribute is broken" $ do
             testWidth "bezel { y of type sign, x of type humanity }" 8
             testWidth "bezel { y of type sign, y of type bonfire, x of type humanity }" 8
+            testWidth "bezel { x of type humanity, y of type sign, z of type bonfire" 6

--- a/test/test-utils/TestUtils.hs
+++ b/test/test-utils/TestUtils.hs
@@ -72,6 +72,11 @@ extractWidthFromExtra [] = error "The `extra` array doesn't have any `Width` ite
 extractWidthFromExtra (s@ST.Width{} : _) = s
 extractWidthFromExtra (_:ss) = extractWidthFromExtra ss
 
+extractUnionAttrIdFromExtra :: Extractor
+extractUnionAttrIdFromExtra [] = error "The `extra` array doesn't have any `UnionAttrId` item"
+extractUnionAttrIdFromExtra (s@ST.UnionAttrId{} : _) = s
+extractUnionAttrIdFromExtra (_:ss) = extractUnionAttrIdFromExtra ss
+
 runTestForInvalidProgram :: String -> IO ()
 runTestForInvalidProgram program = do
     let ([], tokens) = L.scanTokens program


### PR DESCRIPTION
This PR introduces `ST.Width Int`, `ST.Offset Int` and `ST.UnionAttrId Int` in order to calculate offsets and widths for firelink data types and variables.

## Width
The rules for width calculus are kind of simple:

- Basic data types have a predefined width, as our specs impose
- Arrays and strings have a width of 8 bytes, since we don't know at compile time its final size. The 8 bytes are for the dope-vector
- Sets and pointers have 4 bytes. Their usage dependes entirely on final heap usage
- Records uses the sum of it attributes, trying to pack as much as possible without breaking data aligning. The pseudocode for that is kind of simple:
```
let remainingBytesOnCurrentWord = ST.wordSize - (newAttrWidth % ST.wordSize)
if newAttrWidth <= remainingBytesOnCurrentWord then pack
else go to next word
```
The real algorithm can be found at Parser.y, lines 829-862.
- Unions uses 1 word to save the _active_ parameter, and the max of the widths of its attributes as its width.

By default, all Widths are not word aligned. That leads to better usage of memory of scope stack

## Offset

The offset is calculated incrementing on each variable by its type's width. The algorithm for incrementing is the same as on record attributes, that way we try to minimize in a naive way the amount of memory used.

We also mantain a stack of offsets, that way when we exit a scope we can overwrite the space that it requested. Doing this the amount of data that we spend is (~=) `max offset of every scope`, instead of `sum offset of every scope`.

Other useful aspects of offset are:
- The first record-attribute offset is 0
- Every union-attribute offset is 4 (since the first one is reserved for current attribute)
- Functions and procedures first arg or variable has an offset of 0
- Main program first offset is 0.
