### PR TITLE
Feature/switch tac

### DIFF
--- a/samples/tac_generation/switch1.souls
+++ b/samples/tac_generation/switch1.souls
@@ -1,0 +1,23 @@
+hello ashen one
+
+traveling somewhere
+with
+    var n of type humanity <<= 1
+in your inventory
+
+    enter dungeon with n + 1:
+    1:
+        traveling somewhere
+            n <<= 15
+        you died
+    2:
+        traveling somewhere
+            n <<= 20
+        you died
+    dungeon exited \
+
+    n <<= n - 1 / 2
+
+you died
+
+farewell ashen one

--- a/samples/tac_generation/switch2.souls
+++ b/samples/tac_generation/switch2.souls
@@ -1,0 +1,28 @@
+hello ashen one
+
+traveling somewhere
+with
+    var n of type humanity <<= 1
+in your inventory
+
+    enter dungeon with n - 12 / 2:
+    1:
+        traveling somewhere
+            n <<= 15
+        you died
+    2:
+        traveling somewhere
+            n <<= 14 \
+            n <<= 2 * n
+        you died
+    empty dungeon:
+        traveling somewhere
+            n <<= -1
+        you died
+    dungeon exited \
+
+    n <<= n - 1
+
+you died
+
+farewell ashen one

--- a/src/FireLink/BackEnd/InstructionCodeGenerator.hs
+++ b/src/FireLink/BackEnd/InstructionCodeGenerator.hs
@@ -2,16 +2,16 @@ module FireLink.BackEnd.InstructionCodeGenerator where
 
 import           Control.Monad.RWS                  (lift, tell, unless, when)
 import           FireLink.BackEnd.CodeGenerator
-import           FireLink.BackEnd.ExprCodeGenerator (genCode',
-                                                     genBooleanComparation,
+import           FireLink.BackEnd.ExprCodeGenerator (genBooleanComparation,
+                                                     genCode',
                                                      genCodeForBooleanExpr)
 import           FireLink.FrontEnd.Grammar          (BaseExpr (..),
                                                      CodeBlock (..), Expr (..),
                                                      Id (..), IfCase (..),
                                                      Instruction (..),
-                                                     SwitchCase (..),
-                                                     Program (..))
-import qualified FireLink.FrontEnd.Grammar as G (Op2 (..))
+                                                     Program (..),
+                                                     SwitchCase (..))
+import qualified FireLink.FrontEnd.Grammar          as G (Op2 (..))
 import           FireLink.FrontEnd.TypeChecking     (Type (..))
 import           TACType
 import qualified TACType                            as TAC


### PR DESCRIPTION
Closes #105 

Switch conditionals are generated as follows (comment copied from the PR code):

```
Selection by cases statement (switch)
The code-generation is similar to that of a conditional statement.

Note that the base expression is evaluated just once, in order to avoid
undesired repetition of side effects, and also as an optimization.

If we are generating the last case, the next instruction is right beneath,
so no `goto falseLabel` is generated.

Otherwise, the next instruction of a swith case is the next instruction right
after the switch whole block.

One consideration: if a default case is provided, then it's generated as a normal
switch case in which the given expr matches the base expr (basically,
a comparison of the base expression against itself is raised). This can be
further optimized to remove the unnecessary comparison.
``