### PR TITLE
Feature/bounded iters tac

### DIFF
--- a/samples/tac_generation/fori1.souls
+++ b/samples/tac_generation/fori1.souls
@@ -1,0 +1,17 @@
+hello ashen one
+
+traveling somewhere
+with
+    var n of type humanity <<= 0,
+    var i of type humanity
+in your inventory
+
+    upgrading n with 1 soul until level 10
+        traveling somewhere
+            i <<= 1
+        you died
+    max level reached
+
+you died
+
+farewell ashen one

--- a/samples/tac_generation/fori2.souls
+++ b/samples/tac_generation/fori2.souls
@@ -1,0 +1,19 @@
+hello ashen one
+
+traveling somewhere
+with
+    var n of type humanity <<= 0,
+    var i of type humanity
+in your inventory
+
+    upgrading n with 1 soul until level 10
+        traveling somewhere
+            i <<= 1
+        you died
+    max level reached \
+
+    n <<= 10
+
+you died
+
+farewell ashen one

--- a/samples/tac_generation/fori3.souls
+++ b/samples/tac_generation/fori3.souls
@@ -1,0 +1,17 @@
+hello ashen one
+
+traveling somewhere
+with
+    var n of type humanity <<= 0,
+    var i of type humanity <<= 5
+in your inventory
+
+    upgrading n with i souls until level 10
+        traveling somewhere
+            i <<= i - 1
+        you died
+    max level reached
+
+you died
+
+farewell ashen one

--- a/samples/tac_generation/switch1.souls
+++ b/samples/tac_generation/switch1.souls
@@ -1,0 +1,23 @@
+hello ashen one
+
+traveling somewhere
+with
+    var n of type humanity <<= 1
+in your inventory
+
+    enter dungeon with n + 1:
+    1:
+        traveling somewhere
+            n <<= 15
+        you died
+    2:
+        traveling somewhere
+            n <<= 20
+        you died
+    dungeon exited \
+
+    n <<= n - 1 / 2
+
+you died
+
+farewell ashen one

--- a/samples/tac_generation/switch2.souls
+++ b/samples/tac_generation/switch2.souls
@@ -1,0 +1,28 @@
+hello ashen one
+
+traveling somewhere
+with
+    var n of type humanity <<= 1
+in your inventory
+
+    enter dungeon with n - 12 / 2:
+    1:
+        traveling somewhere
+            n <<= 15
+        you died
+    2:
+        traveling somewhere
+            n <<= 14 \
+            n <<= 2 * n
+        you died
+    empty dungeon:
+        traveling somewhere
+            n <<= -1
+        you died
+    dungeon exited \
+
+    n <<= n - 1
+
+you died
+
+farewell ashen one

--- a/src/FireLink/BackEnd/ExprCodeGenerator.hs
+++ b/src/FireLink/BackEnd/ExprCodeGenerator.hs
@@ -46,15 +46,7 @@ genCodeForExpr TrileanT exp = do
 genCodeForExpr _ (Op2 op lexpr rexpr) = do
     lId <- genCode' lexpr
     rId <- genCode' rexpr
-    newId <- newtemp
-    let lvalue = TAC.Id newId
-    tell [TAC.ThreeAddressCode
-            { TAC.tacOperand = operation
-            , TAC.tacLvalue = Just lvalue
-            , TAC.tacRvalue1 = Just lId
-            , TAC.tacRvalue2 = Just rId
-            }]
-    return lvalue
+    genOp2Code operation lId rId
     where
         operation :: TAC.Operation
         operation = mapOp2ToTacOperation op
@@ -77,6 +69,18 @@ genCodeForExpr _ (Op1 Negate expr) = do
     return lvalue
 
 genCodeForExpr _ e = error $ "This expression hasn't been implemented " ++ show e
+
+genOp2Code :: TAC.Operation -> OperandType -> OperandType -> CodeGenMonad OperandType
+genOp2Code operation lId rId = do
+    newId <- newtemp
+    let lvalue = TAC.Id newId
+    tell [TAC.ThreeAddressCode
+            { TAC.tacOperand = operation
+            , TAC.tacLvalue = Just lvalue
+            , TAC.tacRvalue1 = Just lId
+            , TAC.tacRvalue2 = Just rId
+            }]
+    return lvalue
 
 genCodeForBooleanExpr :: BaseExpr -> OperandType -> OperandType -> CodeGenMonad ()
 

--- a/src/FireLink/BackEnd/InstructionCodeGenerator.hs
+++ b/src/FireLink/BackEnd/InstructionCodeGenerator.hs
@@ -2,16 +2,16 @@ module FireLink.BackEnd.InstructionCodeGenerator where
 
 import           Control.Monad.RWS                  (lift, tell, unless, when)
 import           FireLink.BackEnd.CodeGenerator
-import           FireLink.BackEnd.ExprCodeGenerator (genCode',
-                                                     genBooleanComparation,
+import           FireLink.BackEnd.ExprCodeGenerator (genBooleanComparation,
+                                                     genCode',
                                                      genCodeForBooleanExpr)
 import           FireLink.FrontEnd.Grammar          (BaseExpr (..),
                                                      CodeBlock (..), Expr (..),
                                                      Id (..), IfCase (..),
                                                      Instruction (..),
-                                                     SwitchCase (..),
-                                                     Program (..))
-import qualified FireLink.FrontEnd.Grammar as G (Op2 (..))
+                                                     Program (..),
+                                                     SwitchCase (..))
+import qualified FireLink.FrontEnd.Grammar          as G (Op2 (..))
 import           FireLink.FrontEnd.TypeChecking     (Type (..))
 import           TACType
 import qualified TACType                            as TAC


### PR DESCRIPTION
Closes #110 

**Note that this PR requires previous merging of PR #109 to the master branch**

Bounded iteration instructions are generated as follows (comment copied from the PR code):

```
Bounded looping statement
Code generation is similar to that of an indeterminate loop,
in which the guard is to check whether the iteration variable has already
reached the bound, and additional instructions are added underneath the code block
in order to successfully update the value of the iteration variable
after every iteration.
```