### PR TITLE
Optimizations & improvements

### DIFF
--- a/samples/tac_generation/arithmetic/arithmetic9.souls
+++ b/samples/tac_generation/arithmetic/arithmetic9.souls
@@ -1,0 +1,8 @@
+hello ashen one
+
+traveling somewhere
+with var n of type humanity, var m of type humanity in your inventory
+    m <<= n + 1
+you died
+
+farewell ashen one

--- a/samples/tac_generation/boolean/boolean7.souls
+++ b/samples/tac_generation/boolean/boolean7.souls
@@ -1,0 +1,17 @@
+hello ashen one
+
+invocation f
+with skill of type bonfire
+    traveling somewhere
+        go back with lit
+    you died
+after this return to your world
+
+traveling somewhere
+with
+    var n of type bonfire
+in your inventory
+    n <<= summon f
+you died
+
+farewell ashen one

--- a/src/FireLink/BackEnd/CodeGenerator.hs
+++ b/src/FireLink/BackEnd/CodeGenerator.hs
@@ -23,6 +23,7 @@ type Offset = Int
 data TACSymEntry
     = TACTemporal String Offset
     | TACVariable DictionaryEntry Offset
+    deriving Eq
 
 getTACSymEntryOffset :: TACSymEntry -> Int
 getTACSymEntryOffset (TACTemporal _ o) = o

--- a/src/FireLink/BackEnd/Optimizer.hs
+++ b/src/FireLink/BackEnd/Optimizer.hs
@@ -9,10 +9,16 @@ import           TACType
 -- | returns a (hopefully optimized) list of TAC.
 type Optimization = [TAC] -> [TAC]
 
+-- | Applies optimizations iteratively to the TAC list until
+-- | stability is reached (i.e. until it converges)
+-- | (src: https://stackoverflow.com/a/23924238)
+optimize :: Optimization
+optimize = until =<< ((==) =<<) $ optimize'
+
 -- | Composes all valid optimizations into one function to be applied
 -- | to a generated three-address code list.
-optimize :: Optimization
-optimize = foldr (.) id optimizations
+optimize' :: Optimization
+optimize' = foldr (.) id optimizations
 
 -- | A list with all currently valid optimizations.
 optimizations :: [Optimization]

--- a/src/FireLink/FrontEnd/Grammar.hs
+++ b/src/FireLink/FrontEnd/Grammar.hs
@@ -150,7 +150,7 @@ instance Show Expr where
 
 newtype Program
   = Program CodeBlock
-  deriving Show
+  deriving (Eq, Show)
 
 data Instruction
   = InstAsig Expr Expr
@@ -166,7 +166,7 @@ data Instruction
   | InstWhile Expr CodeBlock
   | InstMalloc Expr
   | InstFreeMem Expr
-  deriving Show
+  deriving (Eq, Show)
 
 getInstrOffset :: Instruction -> Int
 getInstrOffset i = case i of
@@ -186,16 +186,16 @@ getInstrOffset i = case i of
 
 data IfCase
   = GuardedCase Expr CodeBlock
-  deriving Show
+  deriving (Eq, Show)
 
 data SwitchCase
   = Case Expr CodeBlock
   | DefaultCase CodeBlock
-  deriving Show
+  deriving (Eq, Show)
 
 data CodeBlock
   = CodeBlock Instructions Int
-  deriving Show
+  deriving (Eq, Show)
 
 data RecoverableError
   = MissingProgramEnd

--- a/src/FireLink/FrontEnd/SymTable.hs
+++ b/src/FireLink/FrontEnd/SymTable.hs
@@ -61,7 +61,7 @@ data Extra
 
     -- Unique identifier for each union-attribute
     | UnionAttrId Int
-    deriving Show
+    deriving (Eq, Show)
 
 isWidthExtra :: Extra -> Bool
 isWidthExtra Width{} = True
@@ -163,7 +163,7 @@ data DictionaryEntry = DictionaryEntry
     , scope :: !Scope -- ^ Current scope at entry insertion
     , entryType :: !(Maybe String) -- (pointer to another) entry
     , extra :: ![Extra] -- extra data semantic to the real dictionary
-    } deriving Show
+    } deriving (Eq, Show)
 
 type DictionaryEntries = [DictionaryEntry]
 


### PR DESCRIPTION
This PR adds the following improvements to the optimization module:

**1.** The optimization function now iterates on itself until a stable TAC list is reached (fixed-point)

**2.** Optimizes redundant operations. That is, if there are two sequential instructions such that  instruction A performs x := y op z, and instruction B performs k := x, then both are merged into a new instruction C that performs k := y op z.

An example:

```
        (n)base[0] := 0
        (m)base[4] := 0
        (_t0)base[8] := small humanity(1)
        (_t1)base[12] := (n)base[0] + (_t0)base[8]
        (m)base[4] := (_t1)base[12]
```

changes to

```
        (n)base[0] := 0
        (m)base[4] := 0
        (_t0)base[8] := small humanity(1)
        (m)base[4] := (n)base[0] + (_t0)base[8]
```

**3.** Boolean functions that are saved to an ID are now saved directly to it, instead of to a temporal variable. _Closes #136._

Example:

```
        (n)base[0] := true
        goto 0
        (n)base[0] := false
0:
        (_t0)base[4] := call f, 0
        if (_t0)base[4] = true then goto 4
        goto 5
4:
        (n)base[0] := true
        goto 3
5:
        (n)base[0] := false
3:
f:
        (_t1)base[0] := true
        goto 9
        (_t1)base[0] := false
9:
        return (_t1)base[0]
```

changes to

```
        (n)base[0] := true
        goto 0
        (n)base[0] := false
0:
        (n)base[0] := call f, 0
f:
        (_t1)base[0] := true
        goto 7
        (_t1)base[0] := false
7:
        return (_t1)base[0]
```

**4.** Remove unreachable "sandwiched" instructions, that is, if there are 3-tuples of sequential instructions (A, B, C) such that instruction A is a jump to a label z, and instruction C is label z (which means that B would **never** be executed), then instruction B is removed.

Example:

The previous code fragment

```
        (n)base[0] := true
        goto 0
        (n)base[0] := false
0:
        (n)base[0] := call f, 0
f:
        (_t1)base[0] := true
        goto 7
        (_t1)base[0] := false
7:
        return (_t1)base[0]
```

is changed to

```
        (n)base[0] := true
        (n)base[0] := call f, 0
f:
        (_t1)base[0] := true
        return (_t1)base[0]
```