### PR TITLE
Return from main

### DIFF
--- a/src/FireLink/BackEnd/InstructionCodeGenerator.hs
+++ b/src/FireLink/BackEnd/InstructionCodeGenerator.hs
@@ -42,6 +42,11 @@ instance GenerateCode Program where
             , tacLvalue = Nothing
             , tacRvalue1 = Just $ Label "_main"
             , tacRvalue2 = Just $ Constant ("0", SmallIntT)
+            }, ThreeAddressCode
+            { tacOperand = Exit
+            , tacLvalue = Nothing
+            , tacRvalue1 = Nothing
+            , tacRvalue2 = Nothing
             }]
 
         mapM_ genBlock allFunctions

--- a/src/FireLink/FrontEnd/Parser.y
+++ b/src/FireLink/FrontEnd/Parser.y
@@ -189,11 +189,11 @@ NON_OPENER_CODEBLOCK :: { G.CodeBlock }
                                                                              checkRecoverableError $1 $4
                                                                              let (blockInsts, blockO) = $3
                                                                              let o = if blockO /= 0 then blockO else declarO
-                                                                             return $ G.CodeBlock (asigInsts ++ reverse blockInsts) o }
+                                                                             return $ G.CodeBlock (asigInsts ++ reverse blockInsts ++ [G.InstReturn]) o }
   | instructionsBegin INSTRL NON_OPENER_INSTEND                         {% do
                                                                              checkRecoverableError $1 $3
                                                                              let (blockInsts, blockO) = $2
-                                                                             return $ G.CodeBlock (reverse blockInsts) blockO }
+                                                                             return $ G.CodeBlock (reverse blockInsts ++ [G.InstReturn]) blockO }
 
 NON_OPENER_INSTEND :: { Maybe G.RecoverableError }
   : instructionsEnd                                                     { Nothing }

--- a/test/Parser/BoundedLoopStructuresSpec.hs
+++ b/test/Parser/BoundedLoopStructuresSpec.hs
@@ -30,5 +30,5 @@ spec = describe "Bounded loop structures" $ do
         \       with orange saponite say @hello@ \
         \   you died \
         \ max level reached") (\(Program (CodeBlock [
-            InstFor (Id Token {cleanedString="aa"} _) Expr{expAst=(IntLit 2)} Expr{expAst=(IntLit 123)} (CodeBlock _ _)
+            InstFor (Id Token {cleanedString="aa"} _) Expr{expAst=(IntLit 2)} Expr{expAst=(IntLit 123)} (CodeBlock _ _), InstReturn
         ] _)) -> True)

--- a/test/Parser/ConditionalStructuresSpec.hs
+++ b/test/Parser/ConditionalStructuresSpec.hs
@@ -37,7 +37,7 @@ spec = do
                 GuardedCase
                     Expr{expAst=TrueLit}
                     (CodeBlock [InstPrint Expr{expAst=(StringLit "hello world")}] _)
-                ]] _)) -> True)
+                ], InstReturn] _)) -> True)
 
         it "accepts a selection block with sevearal if/elseif statments and parses them in order" $
             runTestForValidProgram (buildProgram "\
@@ -53,7 +53,7 @@ spec = do
                     Expr{expAst=TrueLit}
                     (CodeBlock [InstPrint Expr{expAst=(StringLit "hello world")}] _),
                 GuardedCase Expr{expAst=FalseLit} (CodeBlock [InstPrint Expr{expAst=(StringLit "goodbye")}] _)
-                ]] _)) -> True)
+                ], InstReturn] _)) -> True)
 
         it "accepts a selection block with an if and else statment" $
             runTestForValidProgram (buildProgram "\
@@ -71,7 +71,7 @@ spec = do
                 GuardedCase
                     Expr{expAst=TrueLit}
                     (CodeBlock [InstPrint Expr{expAst=(StringLit "goodbye")}] _)
-                ]] _)) -> True)
+                ], InstReturn] _)) -> True)
         it "rejects a selection block with more than 1 else statment" $
             runTestForInvalidProgram $ buildProgram "\
             \ lit: \
@@ -113,7 +113,7 @@ spec = do
             \       with orange saponite say @hello@ \
             \   you died") (\(Program (CodeBlock [InstSwitch Expr{expAst=(IdExpr (Id Token {cleanedString="a"} _))} [
                     Case Expr{expAst=(IntLit 1)} (CodeBlock [InstPrint Expr{expAst=(StringLit "hello")}] _)
-                ]] _)) -> True)
+                ], InstReturn] _)) -> True)
 
         it "rejects switch statement with more than 1 default" $
             runTestForInvalidProgram $ buildProgram "\
@@ -141,7 +141,7 @@ spec = do
             \   you died") (\(Program (CodeBlock [InstSwitch Expr{expAst=(IdExpr (Id Token {cleanedString="a"} _))} [
                     Case Expr{expAst=(IntLit 1)} (CodeBlock [InstPrint Expr{expAst=(StringLit "hello")}] _),
                     Case Expr{expAst=(IntLit 2)} (CodeBlock [InstPrint Expr{expAst=(StringLit "bye")}] _)
-                ]] _)) -> True)
+                ], InstReturn] _)) -> True)
 
         it "accepts swith statement with several non-default cases and one default" $
             runTestForValidProgram (buildProgram "\
@@ -160,5 +160,5 @@ spec = do
                     Case Expr{expAst=(IntLit 1)} (CodeBlock [InstPrint Expr{expAst=StringLit "hello"}] _),
                     Case Expr{expAst=(IntLit 2)} (CodeBlock [InstPrint Expr{expAst=StringLit "bye"}] _),
                     DefaultCase (CodeBlock [InstPrint Expr{expAst=(StringLit "empty")}] _)
-                ]] _)) -> True)
+                ], InstReturn] _)) -> True)
 

--- a/test/Parser/ExpressionsSpec.hs
+++ b/test/Parser/ExpressionsSpec.hs
@@ -25,43 +25,43 @@ spec = describe "Expressions" $ do
             CodeBlock
                 [InstReturnWith Expr{expAst=(
                     Op2 Add Expr{expAst=(IntLit 1)} Expr{expAst=(IntLit 2)}
-                    )}] _)) -> True)
+                    )}, InstReturn] _)) -> True)
     it "accepts `1 + 2 + 3` as an expression and associates to the left" $
         runTestForExpr "1 + 2 + 3" (\(Program (
             CodeBlock
                 [InstReturnWith Expr{expAst=(
                     Op2 Add Expr{expAst=(Op2 Add Expr{expAst=(IntLit 1)} Expr{expAst=(IntLit 2)})} Expr{expAst=(IntLit 3)}
-                    )}] _)) -> True)
+                    )}, InstReturn] _)) -> True)
     it "accepts `1 - 2` as an expression" $
         runTestForExpr "1 - 2" (\(Program (
             CodeBlock
-                [InstReturnWith Expr{expAst=(Op2 Substract Expr{expAst=(IntLit 1)} Expr{expAst=(IntLit 2)})}] _)) -> True)
+                [InstReturnWith Expr{expAst=(Op2 Substract Expr{expAst=(IntLit 1)} Expr{expAst=(IntLit 2)})}, InstReturn] _)) -> True)
     it "accepts `1 - 2 - 3` as an expression and associates to the left" $
         runTestForExpr "1 - 2 - 3" (\(Program (
             CodeBlock
                 [InstReturnWith Expr{expAst=(
                     Op2 Substract
                         Expr{expAst=(Op2 Substract Expr{expAst=(IntLit 1)} Expr{expAst=(IntLit 2)})}
-                        Expr{expAst=(IntLit 3)})}] _)) -> True)
+                        Expr{expAst=(IntLit 3)})}, InstReturn] _)) -> True)
     it "accepts `1 - 2 + 3` as an expression and associates to the left (1 - 2) + 3" $
         runTestForExpr "1 - 2 + 3" (\(Program (
             CodeBlock
                 [InstReturnWith Expr{expAst=(
                     Op2 Add
                         Expr{expAst=(Op2 Substract Expr{expAst=(IntLit 1)} Expr{expAst=(IntLit 2)})}
-                        Expr{expAst=(IntLit 3)})}] _)) -> True)
+                        Expr{expAst=(IntLit 3)})}, InstReturn] _)) -> True)
     it "accepts `1 + 2 - 3` as an expression and associates to the left (1 + 2) - 3" $
         runTestForExpr "1 + 2 - 3" (\(Program (
             CodeBlock
                 [InstReturnWith Expr{expAst=(
                     Op2 Substract
                         Expr{expAst=(Op2 Add Expr{expAst=(IntLit 1)} Expr{expAst=(IntLit 2)})}
-                        Expr{expAst=(IntLit 3)})}] _)) -> True)
+                        Expr{expAst=(IntLit 3)})}, InstReturn] _)) -> True)
     it "accepts `1 * 2` as an expression" $
         runTestForExpr "1 * 2" (\(Program (
             CodeBlock
                 [InstReturnWith Expr{expAst=(
-                    Op2 Multiply Expr{expAst=(IntLit 1)} Expr{expAst=(IntLit 2)})}] _)) -> True)
+                    Op2 Multiply Expr{expAst=(IntLit 1)} Expr{expAst=(IntLit 2)})}, InstReturn] _)) -> True)
     it "accepts `1 * 2 * 3` as an expression and associates to the left" $
         runTestForExpr "1 * 2 * 3" (\(Program (
             CodeBlock
@@ -73,7 +73,7 @@ spec = describe "Expressions" $ do
                             )}
                         Expr{expAst=(IntLit 3)}
                     )}
-                ] _)) -> True)
+                , InstReturn] _)) -> True)
     it "accepts `1 * 2 + 3` as an expression and associates to the left" $
         runTestForExpr "1 * 2 + 3" (\(Program (
             CodeBlock
@@ -82,7 +82,7 @@ spec = describe "Expressions" $ do
                         Expr{expAst=(Op2 Multiply Expr{expAst=(IntLit 1)} Expr{expAst=(IntLit 2)})}
                         Expr{expAst=(IntLit 3)}
                     )}
-                ] _)) -> True)
+                , InstReturn] _)) -> True)
     it "accepts `1 + 2 * 3` as an expression and associates to the left" $
         runTestForExpr "1 + 2 * 3" (\(Program (
             CodeBlock
@@ -91,7 +91,7 @@ spec = describe "Expressions" $ do
                         Expr{expAst=(IntLit 1)}
                         Expr{expAst=(Op2 Multiply Expr{expAst=(IntLit 2)} Expr{expAst=(IntLit 3)})}
                     )}
-                ] _)) -> True)
+                , InstReturn] _)) -> True)
     it "accepts `1 / 2` as an expression" $
         runTestForExpr "1 / 2" (\(Program (
             CodeBlock
@@ -100,7 +100,7 @@ spec = describe "Expressions" $ do
                         Expr{expAst=(IntLit 1)}
                         Expr{expAst=(IntLit 2)}
                     )}
-                ] _)) -> True)
+                , InstReturn] _)) -> True)
     it "accepts `1 / 2 / 3` as an expression and associates to the left" $
         runTestForExpr "1 / 2 / 3" (\(Program (
             CodeBlock
@@ -109,7 +109,7 @@ spec = describe "Expressions" $ do
                         Expr{expAst=(Op2 Divide Expr{expAst=(IntLit 1)} Expr{expAst=(IntLit 2)})}
                         Expr{expAst=(IntLit 3)}
                     )}
-                ] _)) -> True)
+                , InstReturn] _)) -> True)
     it "accepts `1 / 2 + 3` as an expression and associates to the left" $
         runTestForExpr "1 / 2 + 3" (\(Program (
             CodeBlock
@@ -120,7 +120,7 @@ spec = describe "Expressions" $ do
                             Expr{expAst=(IntLit 2)})}
                         Expr{expAst=(IntLit 3)}
                     )}
-                ] _)) -> True)
+                , InstReturn] _)) -> True)
     it "accepts `1 + 2 / 3` as an expression and associates to the left" $
         runTestForExpr "1 + 2 / 3" (\(Program (
             CodeBlock
@@ -131,7 +131,7 @@ spec = describe "Expressions" $ do
                             Expr{expAst=(IntLit 2)}
                             Expr{expAst=(IntLit 3)})}
                     )}
-                ] _)) -> True)
+                , InstReturn] _)) -> True)
     it "accepts `1 % 2` as an expression" $
         runTestForExpr "1 % 2" (\(Program (
             CodeBlock
@@ -140,7 +140,7 @@ spec = describe "Expressions" $ do
                         Expr{expAst=(IntLit 1)}
                         Expr{expAst=(IntLit 2)}
                     )}
-                ] _)) -> True)
+                , InstReturn] _)) -> True)
     it "accepts `1 % 2 % 3` as an expression and associates to the left" $
         runTestForExpr "1 % 2 % 3" (\(Program (
             CodeBlock
@@ -149,7 +149,7 @@ spec = describe "Expressions" $ do
                         Expr{expAst=(Op2 Mod Expr{expAst=(IntLit 1)} Expr{expAst=(IntLit 2)})}
                         Expr{expAst=(IntLit 3)}
                     )}
-                ] _)) -> True)
+                , InstReturn] _)) -> True)
     it "accepts `1 % 2 + 3` as an expression and associates to the left" $
         runTestForExpr "1 % 2 + 3" (\(Program (
             CodeBlock
@@ -158,7 +158,7 @@ spec = describe "Expressions" $ do
                         Expr{expAst=(Op2 Mod Expr{expAst=(IntLit 1)} Expr{expAst=(IntLit 2)})}
                         Expr{expAst=(IntLit 3)}
                     )}
-                ] _)) -> True)
+                , InstReturn] _)) -> True)
     it "accepts `1 + 2 % 3` as an expression and parse % as more precedent" $
         runTestForExpr "1 + 2 % 3" (\(Program (
             CodeBlock
@@ -166,12 +166,12 @@ spec = describe "Expressions" $ do
                     Op2 Add
                         Expr{expAst=(IntLit 1)}
                         Expr{expAst=(Op2 Mod Expr{expAst=(IntLit 2)} Expr{expAst=(IntLit 3)})}
-                        )}] _)) -> True)
+                        )}, InstReturn] _)) -> True)
     it "accepts `- 1` as an expression and associates to the left" $
         runTestForExpr "- 1" (\(Program (
             CodeBlock
                 [InstReturnWith Expr{expAst=(
-                    Op1 Negate Expr{expAst=(IntLit 1)})}] _)) -> True)
+                    Op1 Negate Expr{expAst=(IntLit 1)})}, InstReturn] _)) -> True)
     it "rejects `- - 1` as an expression and associates to the left" $
         runTestForExpr "- - 1" (\(Program (
             CodeBlock
@@ -180,7 +180,7 @@ spec = describe "Expressions" $ do
                         Op1 Negate Expr{expAst=(IntLit 1)}
                         )}
                     )}
-                ] _)) -> True)
+                , InstReturn] _)) -> True)
     it "accepts `1 lt 2` as an expression and associates to the left" $
         runTestForExpr "1 lt 2" (\(Program (
             CodeBlock
@@ -189,7 +189,7 @@ spec = describe "Expressions" $ do
                         Expr{expAst=(IntLit 1)}
                         Expr{expAst=(IntLit 2)}
                     )}
-                ] _)) -> True)
+                , InstReturn] _)) -> True)
     it "accepts `1 lt 2 + 3` as an expression and associates to the right (1 lt (2 + 3))" $
         runTestForExpr "1 lt 2 + 3" (\(Program (
             CodeBlock
@@ -201,7 +201,7 @@ spec = describe "Expressions" $ do
                             Expr{expAst=(IntLit 3)}
                             )}
                         )}
-                    ] _)) -> True)
+                    , InstReturn] _)) -> True)
     it "accepts `1 lte 2` as an expression and associates to the left" $
         runTestForExpr "1 lte 2" (\(Program (
             CodeBlock
@@ -210,7 +210,7 @@ spec = describe "Expressions" $ do
                         Expr{expAst=(IntLit 1)}
                         Expr{expAst=(IntLit 2)}
                     )}
-                ] _)) -> True)
+                , InstReturn] _)) -> True)
     it "accepts `1 lte 2 + 3` as an expression and associates to the right (1 lte (2 + 3))" $
         runTestForExpr "1 lte 2 + 3" (\(Program (
             CodeBlock
@@ -222,7 +222,7 @@ spec = describe "Expressions" $ do
                             Expr{expAst=(IntLit 3)}
                             )}
                     )}
-                ] _)) -> True)
+                , InstReturn] _)) -> True)
     it "accepts `1 gt 2` as an expression and associates to the left" $
         runTestForExpr "1 gt 2" (\(Program (
             CodeBlock
@@ -231,7 +231,7 @@ spec = describe "Expressions" $ do
                         Expr{expAst=(IntLit 1)}
                         Expr{expAst=(IntLit 2)}
                         )}
-                    ] _)) -> True)
+                    , InstReturn] _)) -> True)
     it "accepts `1 gt 2 + 3` as an expression and associates to the right (1 gt (2 + 3))" $
         runTestForExpr "1 gt 2 + 3" (\(Program (
             CodeBlock
@@ -242,7 +242,7 @@ spec = describe "Expressions" $ do
                             Expr{expAst=(IntLit 2)}
                             Expr{expAst=(IntLit 3)}
                             )}
-                        )}] _)) -> True)
+                        )}, InstReturn] _)) -> True)
     it "accepts `1 gte 2` as an expression and associates to the left" $
         runTestForExpr "1 gte 2" (\(Program (
             CodeBlock
@@ -250,7 +250,7 @@ spec = describe "Expressions" $ do
                     Op2 Gte
                         Expr{expAst=(IntLit 1)}
                         Expr{expAst=(IntLit 2)}
-                        )}] _)) -> True)
+                        )}, InstReturn] _)) -> True)
     it "accepts `1 gte 2 + 3` as an expression and associates to the right (1 gte (2 + 3))" $
         runTestForExpr "1 gte 2 + 3" (\(Program (
             CodeBlock
@@ -258,7 +258,7 @@ spec = describe "Expressions" $ do
                     Op2 Gte
                         Expr{expAst=(IntLit 1)}
                         Expr{expAst=(Op2 Add Expr{expAst=(IntLit 2)} Expr{expAst=(IntLit 3)})}
-                        )}] _)) -> True)
+                        )}, InstReturn] _)) -> True)
     it "accepts `1 eq 2` as an expression and associates to the left" $
         runTestForExpr "1 eq 2" (\(Program (
             CodeBlock
@@ -267,7 +267,7 @@ spec = describe "Expressions" $ do
                         Expr{expAst=(IntLit 1)}
                         Expr{expAst=(IntLit 2)}
                         )}
-                    ] _)) -> True)
+                    , InstReturn] _)) -> True)
     it "accepts `1 eq 2 + 3` as an expression and associates to the right (1 eq (2 + 3))" $
         runTestForExpr "1 eq 2 + 3" (\(Program (
             CodeBlock
@@ -276,7 +276,7 @@ spec = describe "Expressions" $ do
                         Expr{expAst=(IntLit 1)}
                         Expr{expAst=(Op2 Add Expr{expAst=(IntLit 2)} Expr{expAst=(IntLit 3)})}
                     )}
-                ] _)) -> True)
+                , InstReturn] _)) -> True)
     it "accepts `1 eq 2 eq 3 as an expression and associates to the left (1 eq 2) eq 3" $
         runTestForExpr "1 eq 2 eq 3" (\(Program (
             CodeBlock
@@ -287,7 +287,7 @@ spec = describe "Expressions" $ do
                             Expr{expAst=(IntLit 2)})}
                         Expr{expAst=(IntLit 3)}
                     )}
-                ] _)) -> True)
+                , InstReturn] _)) -> True)
     it "accepts `1 neq 2` as an expression and associates to the left" $
         runTestForExpr "1 neq 2" (\(Program (
             CodeBlock
@@ -295,7 +295,7 @@ spec = describe "Expressions" $ do
                     Op2 Neq
                         Expr{expAst=(IntLit 1)}
                         Expr{expAst=(IntLit 2)}
-                    )}] _)) -> True)
+                    )}, InstReturn] _)) -> True)
     it "accepts `1 neq 2 + 3` as an expression and associates to the right (1 neq (2 + 3))" $
         runTestForExpr "1 neq 2 + 3" (\(Program (
             CodeBlock
@@ -304,7 +304,7 @@ spec = describe "Expressions" $ do
                         Expr{expAst=(IntLit 1)}
                         Expr{expAst=(Op2 Add Expr{expAst=(IntLit 2)} Expr{expAst=(IntLit 3)})}
                         )}
-                    ] _)) -> True)
+                    , InstReturn] _)) -> True)
     it "accepts `1 neq 2 neq 3 as an expression and associates to the left (1 neq 2) neq 3" $
         runTestForExpr "1 neq 2 neq 3" (\(Program (
             CodeBlock
@@ -314,7 +314,7 @@ spec = describe "Expressions" $ do
                             Expr{expAst=(IntLit 1)}
                             Expr{expAst=(IntLit 2)})}
                         Expr{expAst=(IntLit 3)}
-                    )}] _)) -> True)
+                    )}, InstReturn] _)) -> True)
     it "accepts `1 eq 2 neq 3 as an expression and associates to the left (1 eq 2) neq 3" $
         runTestForExpr "1 eq 2 neq 3" (\(Program (
             CodeBlock
@@ -326,7 +326,7 @@ spec = describe "Expressions" $ do
                             )}
                         Expr{expAst=(IntLit 3)}
                     )}
-                ] _)) -> True)
+                , InstReturn] _)) -> True)
 
     it "accepts `lit and unlit` as an expression" $
         runTestForExpr "lit and unlit" (\(Program (
@@ -336,7 +336,7 @@ spec = describe "Expressions" $ do
                         Expr{expAst=TrueLit}
                         Expr{expAst=FalseLit}
                     )}
-                ] _)) -> True)
+                , InstReturn] _)) -> True)
     it "accepts `lit or unlit` as an expression" $
         runTestForExpr "lit or unlit" (\(Program (
             CodeBlock
@@ -345,13 +345,13 @@ spec = describe "Expressions" $ do
                         Expr{expAst=TrueLit}
                         Expr{expAst=FalseLit}
                     )}
-                ] _)) -> True)
+                , InstReturn] _)) -> True)
     it "accepts `not unlit` as an expression" $
         runTestForExpr "not unlit" (\(Program (
             CodeBlock
                 [InstReturnWith Expr{expAst=(
                     Op1 Not Expr{expAst=FalseLit})
-                    }]
+                    }, InstReturn]
                  _)) -> True)
     it "accepts `lit and unlit and undiscovered` as an expression associating to the left `(lit and unlit) and undiscovered`" $
         runTestForExpr "lit and unlit and undiscovered" (\(Program (
@@ -360,7 +360,7 @@ spec = describe "Expressions" $ do
                     Op2 And
                         Expr{expAst=(Op2 And Expr{expAst=TrueLit} Expr{expAst=FalseLit})}
                         Expr{expAst=UndiscoveredLit})
-                    }]
+                    }, InstReturn]
                  _)) -> True)
     it "accepts `not lit and unlit` as an expression and `not` has more precedence" $
         runTestForExpr "not lit and unlit" (\(Program (
@@ -369,7 +369,7 @@ spec = describe "Expressions" $ do
                     Op2 And
                         Expr{expAst=(Op1 Not Expr{expAst=TrueLit})}
                         Expr{expAst=FalseLit}
-                    )}] _)) -> True)
+                    )}, InstReturn] _)) -> True)
 
     it "accepts `ascii_of |n|` as an expression" $
         runTestForExpr "ascii_of |n|" (\(Program (
@@ -378,7 +378,7 @@ spec = describe "Expressions" $ do
                     AsciiOf
                         Expr{expAst=(CharLit 'n')}
                     )}
-                ] _)) -> True)
+                , InstReturn] _)) -> True)
 
     it "accepts `ascii_of |n| + ascii_of |f|` as an expression and parses it as `(ascii_of |n|) + (ascii_of |f|)" $
         runTestForExpr "ascii_of |n| + ascii_of |f|" (\(Program (
@@ -388,7 +388,7 @@ spec = describe "Expressions" $ do
                         Expr{expAst=(AsciiOf Expr{expAst=(CharLit 'n')})}
                         Expr{expAst=(AsciiOf Expr{expAst=(CharLit 'f')})}
                     )}
-                ] _)) -> True)
+                , InstReturn] _)) -> True)
 
     it "accepts `<$$> >-< @@` as an expression" $
         runTestForExpr "<$$> >-< @@" (\(Program (
@@ -397,7 +397,7 @@ spec = describe "Expressions" $ do
                     Op2 ColConcat
                         Expr{expAst=(ArrayLit [])}
                         Expr{expAst=(StringLit "")}
-                    )}]
+                    )}, InstReturn]
                  _)) -> True)
     it "accepts `<$$> >-< @@ >-< {$$}` as an expression and should associate to the left `(<$$> >-< @@) >-< {$$}`" $
         runTestForExpr "<$$> >-< @@ >-< {$$}" (\(Program (
@@ -409,33 +409,33 @@ spec = describe "Expressions" $ do
                             Expr{expAst=(StringLit "")})}
                         Expr{expAst=(SetLit [])}
                         )}
-                ] _)) -> True)
+                , InstReturn] _)) -> True)
     it "accepts `lit union lit` as an expression" $
         runTestForExpr "lit union lit" (\(Program (
             CodeBlock
                 [InstReturnWith Expr{expAst=(
                     Op2 SetUnion
                         Expr{expAst=TrueLit}
-                        Expr{expAst=TrueLit})}] _)) -> True)
+                        Expr{expAst=TrueLit})}, InstReturn] _)) -> True)
     it "accepts `lit intersect lit` as an expression" $
         runTestForExpr "lit intersect lit" (\(Program (
             CodeBlock
                 [InstReturnWith Expr{expAst=(
                     Op2 SetIntersect
                         Expr{expAst=TrueLit}
-                        Expr{expAst=TrueLit})}] _)) -> True)
+                        Expr{expAst=TrueLit})}, InstReturn] _)) -> True)
     it "accepts `lit diff lit` as an expression" $
         runTestForExpr "lit diff lit" (\(Program (
             CodeBlock
                 [InstReturnWith Expr{expAst=(
                     Op2 SetDifference
                         Expr{expAst=TrueLit}
-                        Expr{expAst=TrueLit})}] _)) -> True)
+                        Expr{expAst=TrueLit})}, InstReturn] _)) -> True)
     it "accepts `size lit` as an expression" $
         runTestForExpr "size lit" (\(Program (
             CodeBlock
                 [InstReturnWith Expr{expAst=(
-                    Size Expr{expAst=TrueLit})}] _)) -> True)
+                    Size Expr{expAst=TrueLit})}, InstReturn] _)) -> True)
 
     it "accepts `lit union lit union lit` as an expression and associates to the left" $
         runTestForExpr "lit union lit union lit" (\(Program (
@@ -446,7 +446,7 @@ spec = describe "Expressions" $ do
                             Expr{expAst=TrueLit}
                             Expr{expAst=TrueLit})}
                         Expr{expAst=TrueLit}
-                        )}]
+                        )}, InstReturn]
                      _)) -> True)
     it "accepts `lit intersect lit intersect lit` as an expression and associates to the left" $
         runTestForExpr "lit intersect lit intersect lit" (\(Program (
@@ -457,7 +457,7 @@ spec = describe "Expressions" $ do
                             Expr{expAst=TrueLit}
                             Expr{expAst=TrueLit})}
                         Expr{expAst=TrueLit}
-                        )}]
+                        )}, InstReturn]
                      _)) -> True)
     it "accepts `lit diff lit diff lit` as an expression" $
         runTestForExpr "lit diff lit diff lit" (\(Program (
@@ -468,7 +468,7 @@ spec = describe "Expressions" $ do
                             Expr{expAst=TrueLit}
                             Expr{expAst=TrueLit})}
                         Expr{expAst=TrueLit}
-                    )}]
+                    )}, InstReturn]
                  _)) -> True)
     it "accepts `lit diff lit union lit` as an expression" $
         runTestForExpr "lit diff lit union lit" (\(Program (
@@ -477,7 +477,7 @@ spec = describe "Expressions" $ do
                     Op2 SetDifference
                         Expr{expAst=TrueLit}
                         Expr{expAst=(Op2 SetUnion Expr{expAst=TrueLit} Expr{expAst=TrueLit})}
-                        )}] _)) -> True)
+                        )}, InstReturn] _)) -> True)
 
     it "accepts `lit union lit intersect lit` as an expression and associates to the left" $
         runTestForExpr "lit union lit intersect lit" (\(Program (
@@ -486,14 +486,14 @@ spec = describe "Expressions" $ do
                     Op2 SetIntersect
                         Expr{expAst=(Op2 SetUnion Expr{expAst=TrueLit} Expr{expAst=TrueLit})}
                         Expr{expAst=TrueLit}
-                        )}] _)) -> True)
+                        )}, InstReturn] _)) -> True)
     it "accepts `lit intersect lit union lit` as an expression and associates to the left" $
         runTestForExpr "lit intersect lit union lit" (\(Program (
             CodeBlock
                 [InstReturnWith Expr{expAst=(
                     Op2 SetUnion
                         Expr{expAst=(Op2 SetIntersect Expr{expAst=TrueLit} Expr{expAst=TrueLit})}
-                        Expr{expAst=TrueLit})}] _)) -> True)
+                        Expr{expAst=TrueLit})}, InstReturn] _)) -> True)
 
     it "accepts `a ~> b` as an expression" $
         runTestForExpr "a ~> b" (\(Program (
@@ -503,7 +503,7 @@ spec = describe "Expressions" $ do
                         Expr{expAst=(IdExpr (Id Token {cleanedString="a"} _))}
                         (Id Token {cleanedString="b"} _)
                     )}
-                ] _)) -> True)
+                , InstReturn] _)) -> True)
     it "accepts `a ~> b ~> c` as an expression" $
         runTestForExpr "a ~> b ~> c" (\(Program (
             CodeBlock
@@ -512,7 +512,7 @@ spec = describe "Expressions" $ do
                         Expr{expAst=(Access
                             Expr{expAst=(IdExpr (Id Token {cleanedString="a"} _))}
                             (Id Token {cleanedString="b"} _))}
-                        (Id Token {cleanedString="c"} _))}] _)) -> True)
+                        (Id Token {cleanedString="c"} _))}, InstReturn] _)) -> True)
     it "accepts `a + b ~> c` as an expression" $
         runTestForExpr "a + b ~> c" (\(Program (
             CodeBlock
@@ -521,12 +521,12 @@ spec = describe "Expressions" $ do
                         Expr{expAst=(IdExpr (Id Token {cleanedString="a"} _))}
                         Expr{expAst=(Access
                             Expr{expAst=(IdExpr (Id Token {cleanedString="b"} _))}
-                            (Id Token {cleanedString="c"} _))})}] _)) -> True)
+                            (Id Token {cleanedString="c"} _))})}, InstReturn] _)) -> True)
 
     it "accepts `(a)` as an expression" $
         runTestForExpr "(a)" (\(Program (
             CodeBlock
-                [InstReturnWith Expr{expAst=(IdExpr (Id Token {cleanedString="a"} _))}] _)) -> True)
+                [InstReturnWith Expr{expAst=(IdExpr (Id Token {cleanedString="a"} _))}, InstReturn] _)) -> True)
 
     it "accepts `a<$i$>` as an expression" $
         runTestForExpr "a<$i$>" (\(Program (
@@ -534,7 +534,7 @@ spec = describe "Expressions" $ do
                 [InstReturnWith Expr{expAst=(
                     IndexAccess
                         Expr{expAst=(IdExpr (Id Token {cleanedString="a"} _))}
-                        Expr{expAst=(IdExpr (Id Token {cleanedString="i"} _))})}] _)) -> True)
+                        Expr{expAst=(IdExpr (Id Token {cleanedString="i"} _))})}, InstReturn] _)) -> True)
     it "accepts `a+b<$i$>` as an expression" $
         runTestForExpr "a+b<$i$>" (\(Program (
             CodeBlock
@@ -545,21 +545,21 @@ spec = describe "Expressions" $ do
                             Expr{expAst=(IdExpr (Id Token {cleanedString="b"} _))}
                             Expr{expAst=(IdExpr (Id Token {cleanedString="i"} _))})
                         }
-                    }] _)) -> True)
+                    }, InstReturn] _)) -> True)
     it "rejects `a<$$>` as an expression" $
         runTestForInvalidProgram "a<$$>"
 
     it "accepts `abyss` as an expression" $
         runTestForExpr "abyss" (\(Program (
             CodeBlock
-                [InstReturnWith Expr{expAst=NullLit}] _)) -> True)
+                [InstReturnWith Expr{expAst=NullLit}, InstReturn] _)) -> True)
     it "accepts `throw a a` as an expression" $
         runTestForExpr "throw a a" (\(Program (
             CodeBlock
                 [InstReturnWith Expr {
                     expAst=MemAccess Expr {
                         expAst=IdExpr (Id Token {cleanedString="a"} _)
-                    }}] _)) -> True)
+                    }}, InstReturn] _)) -> True)
     it "rejects `aim a a` as an expression" $
         runTestForInvalidProgram "aim a a"
     it "rejects `recover a a` as an expresion" $
@@ -568,4 +568,4 @@ spec = describe "Expressions" $ do
     it "accepts `summon f` a an expression" $
         runTestForExpr "summon f" (\(Program (
             CodeBlock
-                [InstReturnWith Expr{expAst=EvalFunc (Id Token {cleanedString="f"} _) []}] _)) -> True)
+                [InstReturnWith Expr{expAst=EvalFunc (Id Token {cleanedString="f"} _) []}, InstReturn] _)) -> True)

--- a/test/Parser/ForEachLoopStructuresSpec.hs
+++ b/test/Parser/ForEachLoopStructuresSpec.hs
@@ -32,5 +32,5 @@ spec = describe "Loops over structures" $ do
         \ weaponry repaired") (\(Program (
             CodeBlock [
                 InstForEach (Id Token {cleanedString="a"} _) Expr{expAst=IdExpr (Id Token {cleanedString="b"} _)}
-                    (CodeBlock [InstPrint Expr{expAst=StringLit ""}] _)
+                    (CodeBlock [InstPrint Expr{expAst=StringLit ""}] _), InstReturn
                 ] _)) -> True)

--- a/test/Parser/InstructionsSpec.hs
+++ b/test/Parser/InstructionsSpec.hs
@@ -23,7 +23,7 @@ spec = describe "Instructions" $ do
         \   go back \
         \ you died \
 
-        \ farewell ashen one" (\(Program (CodeBlock [InstReturn] _)) -> True)
+        \ farewell ashen one" (\(Program (CodeBlock [InstReturn, InstReturn] _)) -> True)
     it "accepts program with only 2+ instruction" $
         runTestForValidProgram "\
         \ hello ashen one \
@@ -40,10 +40,10 @@ spec = describe "Instructions" $ do
         \ farewell ashen one" (\(Program (CodeBlock [
             InstAsig _ Expr{expAst=(IntLit 0)},
             InstPrint Expr{expAst=(StringLit "hello world")},
-            InstRead Expr{expAst=(IdExpr (Id Token {cleanedString="patata"} _))}] _)) -> True)
+            InstRead Expr{expAst=(IdExpr (Id Token {cleanedString="patata"} _))}, InstReturn] _)) -> True)
 
     it "accepts assigning as an instruction" $
         runTestForValidProgram (buildProgram "a <<= 1")
         (\(Program (CodeBlock [
             InstAsig Expr{expAst=(IdExpr (Id Token {cleanedString="a"} _))} Expr{expAst=(IntLit 1)}
-        ] _)) -> True)
+        , InstReturn] _)) -> True)

--- a/test/Parser/LiteralsSpec.hs
+++ b/test/Parser/LiteralsSpec.hs
@@ -19,64 +19,64 @@ spec = describe "Literal Values" $ do
     it "accepts `abyss` as a literal" $
         runTestForValidProgram (buildProgramWithLiteral "abyss")
         (\(Program (
-            CodeBlock [InstReturnWith Expr{expAst=NullLit}] _)) -> True)
+            CodeBlock [InstReturnWith Expr{expAst=NullLit}, InstReturn] _)) -> True)
     it "accepts `123` as a literal" $
         runTestForValidProgram (buildProgramWithLiteral "123")
         (\(Program (
-            CodeBlock [InstReturnWith Expr{expAst=(IntLit 123)}] _)) -> True)
+            CodeBlock [InstReturnWith Expr{expAst=(IntLit 123)}, InstReturn] _)) -> True)
     it "accepts `lit` as a literal" $
         runTestForValidProgram (buildProgramWithLiteral "lit")
         (\(Program (
-            CodeBlock [InstReturnWith Expr{expAst=TrueLit}] _)) -> True)
+            CodeBlock [InstReturnWith Expr{expAst=TrueLit}, InstReturn] _)) -> True)
     it "accepts `unlit` as a literal" $
         runTestForValidProgram (buildProgramWithLiteral "unlit")
         (\(Program (
-            CodeBlock [InstReturnWith Expr{expAst=FalseLit}] _)) -> True)
+            CodeBlock [InstReturnWith Expr{expAst=FalseLit}, InstReturn] _)) -> True)
     it "accepts `undiscovered` as a literal" $
         runTestForValidProgram (buildProgramWithLiteral "undiscovered")
         (\(Program (
-            CodeBlock [InstReturnWith Expr{expAst=UndiscoveredLit}] _)) -> True)
+            CodeBlock [InstReturnWith Expr{expAst=UndiscoveredLit}, InstReturn] _)) -> True)
 
     it "accepts `|a|` as a literal" $
         runTestForValidProgram (buildProgramWithLiteral "|a|")
         (\(Program (
-            CodeBlock [InstReturnWith Expr{expAst=(CharLit 'a')}] _)) -> True)
+            CodeBlock [InstReturnWith Expr{expAst=(CharLit 'a')}, InstReturn] _)) -> True)
 
     it "accepts `|\\n|` as a literal" $
         runTestForValidProgram (buildProgramWithLiteral "|\\n|")
         (\(Program (
-            CodeBlock [InstReturnWith Expr{expAst=(CharLit '\n')}] _)) -> True)
+            CodeBlock [InstReturnWith Expr{expAst=(CharLit '\n')}, InstReturn] _)) -> True)
     it "accepts `@@` as a literal" $
         runTestForValidProgram (buildProgramWithLiteral "@@")
         (\(Program (
-            CodeBlock [InstReturnWith Expr{expAst=(StringLit "")}] _)) -> True)
+            CodeBlock [InstReturnWith Expr{expAst=(StringLit "")}, InstReturn] _)) -> True)
     it "accepts `@hello@` as a literal" $
         runTestForValidProgram (buildProgramWithLiteral "@hello@")
         (\(Program (
-            CodeBlock [InstReturnWith Expr{expAst=(StringLit "hello")}] _)) -> True)
+            CodeBlock [InstReturnWith Expr{expAst=(StringLit "hello")}, InstReturn] _)) -> True)
     it "accepts `@\\@@` as a literal" $
         runTestForValidProgram (buildProgramWithLiteral "@\\@@")
         (\(Program (
-            CodeBlock [InstReturnWith Expr{expAst=(StringLit "@")}] _)) -> True)
+            CodeBlock [InstReturnWith Expr{expAst=(StringLit "@")}, InstReturn] _)) -> True)
     it "accepts `1.123` as a literal" $
         runTestForValidProgram (buildProgramWithLiteral "1.123")
         (\(Program (
-            CodeBlock [InstReturnWith Expr{expAst=(FloatLit 1.123)}] _)) -> True)
+            CodeBlock [InstReturnWith Expr{expAst=(FloatLit 1.123)}, InstReturn] _)) -> True)
     it "accepts `0.0` as a literal" $
         runTestForValidProgram (buildProgramWithLiteral "0.0")
         (\(Program (
-            CodeBlock [InstReturnWith Expr{expAst=(FloatLit 0)}] _)) -> True)
+            CodeBlock [InstReturnWith Expr{expAst=(FloatLit 0)}, InstReturn] _)) -> True)
 
     -- array literals
     it "accepts `<$$>` as a literal" $
         runTestForValidProgram (buildProgramWithLiteral "<$$>")
         (\(Program (
-            CodeBlock [InstReturnWith Expr{expAst=(ArrayLit [])}] _)) -> True)
+            CodeBlock [InstReturnWith Expr{expAst=(ArrayLit [])}, InstReturn] _)) -> True)
     it "accepts `<$1$>` as a literal" $
         runTestForValidProgram (buildProgramWithLiteral "<$1$>")
         (\(Program (
             CodeBlock [InstReturnWith Expr{expAst=(ArrayLit [
-                Expr{expAst=IntLit 1}])}] _)) -> True)
+                Expr{expAst=IntLit 1}])}, InstReturn] _)) -> True)
     it "rejects `<$1,$>` as a literal" $
         runTestForInvalidProgram (buildProgramWithLiteral "<$1,$>")
     it "rejects `<$,1$>` as a literal" $
@@ -86,23 +86,23 @@ spec = describe "Literal Values" $ do
         (\(Program (
             CodeBlock [InstReturnWith Expr{expAst=(ArrayLit [
                 Expr{expAst=IntLit 1},
-                Expr{expAst=IntLit 2}])}] _)) -> True)
+                Expr{expAst=IntLit 2}])}, InstReturn] _)) -> True)
     it "accepts `<$<$$>$>` as a literal" $
         runTestForValidProgram (buildProgramWithLiteral "<$<$$>$>")
         (\(Program (
             CodeBlock [InstReturnWith Expr{expAst=(ArrayLit [
-                Expr{expAst=ArrayLit []}])}] _)) -> True)
+                Expr{expAst=ArrayLit []}])}, InstReturn] _)) -> True)
 
     -- set literals
     it "accepts `{$$}` as a literal" $
         runTestForValidProgram (buildProgramWithLiteral "{$$}")
         (\(Program (
-            CodeBlock [InstReturnWith Expr{expAst=SetLit []}] _)) -> True)
+            CodeBlock [InstReturnWith Expr{expAst=SetLit []}, InstReturn] _)) -> True)
     it "accepts `{$1$}` as a literal" $
         runTestForValidProgram (buildProgramWithLiteral "{$1$}")
         (\(Program (
             CodeBlock [InstReturnWith Expr{expAst=(SetLit [
-                Expr{expAst=IntLit  1}])}] _)) -> True)
+                Expr{expAst=IntLit  1}])}, InstReturn] _)) -> True)
     it "rejects `{$1,$}` as a literal" $
         runTestForInvalidProgram (buildProgramWithLiteral "{$1,$}")
     it "rejects `{$,1$}` as a literal" $
@@ -112,10 +112,10 @@ spec = describe "Literal Values" $ do
         (\(Program (
             CodeBlock [InstReturnWith Expr{expAst=(SetLit [
                 Expr{expAst=IntLit 1},
-                Expr{expAst=IntLit 2}])}] _)) -> True)
+                Expr{expAst=IntLit 2}])}, InstReturn] _)) -> True)
     it "accepts `{${$$}$}` as a literal" $
         runTestForValidProgram (buildProgramWithLiteral "{${$$}$}")
         (\(Program (
             CodeBlock [InstReturnWith Expr{expAst=(SetLit [
                 Expr{expAst=SetLit []}
-                ])}] _)) -> True)
+                ])}, InstReturn] _)) -> True)

--- a/test/Parser/ProgramStructureSpec.hs
+++ b/test/Parser/ProgramStructureSpec.hs
@@ -86,4 +86,4 @@ spec = describe "ProgramStructure" $ do
         \   go back \
         \ you died \
 
-        \ farewell ashen one" (\(Program (CodeBlock [InstAsig _ Expr{expAst=(IntLit 0)}, InstReturn] _)) -> True)
+        \ farewell ashen one" (\(Program (CodeBlock [InstAsig _ Expr{expAst=(IntLit 0)}, InstReturn, InstReturn] _)) -> True)

--- a/test/Parser/UnboundedLoopStructuresSpec.hs
+++ b/test/Parser/UnboundedLoopStructuresSpec.hs
@@ -28,4 +28,4 @@ spec = describe "Unbounded looping" $ do
         \ covenant left")  (\(Program (
             CodeBlock [
                 InstWhile Expr{expAst=FalseLit} (CodeBlock _ _)
-                ] _)) -> True)
+                , InstReturn] _)) -> True)

--- a/test/Semantic/SimpleTypesDeclSpec.hs
+++ b/test/Semantic/SimpleTypesDeclSpec.hs
@@ -374,9 +374,10 @@ spec = do
                             G.Expr{G.expAst=(G.IdExpr (G.Id T.Token {T.cleanedString="x"} _))}
                             G.Expr{G.expAst=(G.IntLit 1)}
                         , G.InstPrint G.Expr{G.expAst=(G.StringLit "oh yes")}
+                        , G.InstReturn
                         ] _)) -> True)
 
-        it "Prependes assignment in correct order" $ do
+        it "Prepends assignment in correct order" $ do
             let p = "hello ashen one\n\
 
             \ traveling somewhere\n\
@@ -401,4 +402,5 @@ spec = do
                             G.Expr{G.expAst=(G.IdExpr (G.Id T.Token {T.cleanedString="y"} 1))}
                             G.Expr{G.expAst=(G.IntLit 22)}
                         , G.InstPrint G.Expr{G.expAst=(G.StringLit "oh yes")}
+                        , G.InstReturn
                         ] _)) -> True)


### PR DESCRIPTION
- After the call to `_main`, an `exit` instruction is added
- At parsing, the main procedure codeblock is appended a `Return` in the end (therefore, returning and executing the exit instruction of the previous bullet point)