### PR TITLE
Register allocation by graph coloring

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/tac"]
 	path = src/tac
-	url = git@github.com/german1608/TAC
+	url = https://github.com/german1608/TAC

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/tac"]
 	path = src/tac
-	url = https://github.com/Naty-S/TAC
+	url = git@github.com/german1608/TAC

--- a/firelink.cabal
+++ b/firelink.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 9d5c0932cecce50c848f291166b6311b1b210f1b5279856638cbfc1a5a5a7694
+-- hash: ecdac1aef0d0d81eb79452302af696ff81357e2458f2a713326522c7cfe622e8
 
 name:           firelink
 version:        0.2.0.0
@@ -65,6 +65,7 @@ library
     , extra
     , filepath
     , mtl
+    , optparse-applicative
     , sort
     , split
   default-language: Haskell2010
@@ -85,6 +86,7 @@ executable firelink-exe
     , filepath
     , firelink
     , mtl
+    , optparse-applicative
     , sort
     , split
   default-language: Haskell2010
@@ -124,6 +126,7 @@ test-suite lexer-tests
     , hspec
     , hspec-discover
     , mtl
+    , optparse-applicative
     , sort
     , split
   default-language: Haskell2010
@@ -156,6 +159,7 @@ test-suite parser-tests
     , hspec
     , hspec-discover
     , mtl
+    , optparse-applicative
     , sort
     , split
   default-language: Haskell2010
@@ -192,6 +196,7 @@ test-suite semantic-tests
     , hspec
     , hspec-discover
     , mtl
+    , optparse-applicative
     , sort
     , split
   default-language: Haskell2010
@@ -231,6 +236,7 @@ test-suite type-checking-tests
     , hspec
     , hspec-discover
     , mtl
+    , optparse-applicative
     , sort
     , split
   default-language: Haskell2010

--- a/firelink.cabal
+++ b/firelink.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: d042dd56f1db613d1da861a32be5cf17018800012e34549ab2ebb5ed87dc3424
+-- hash: 9d5c0932cecce50c848f291166b6311b1b210f1b5279856638cbfc1a5a5a7694
 
 name:           firelink
 version:        0.2.0.0
@@ -34,6 +34,7 @@ library
       FireLink.BackEnd.InstructionCodeGenerator
       FireLink.BackEnd.LivenessAnalyser
       FireLink.BackEnd.Optimizer
+      FireLink.BackEnd.RegisterAllocationProcess
       FireLink.BackEnd.Utils
       FireLink.FrontEnd.Errors
       FireLink.FrontEnd.FrontEndCompiler

--- a/firelink.cabal
+++ b/firelink.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.31.2.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 45e094a38a4f91a0730fc409f10a9d3a30bec976fa078adc05fce604599e116a
+-- hash: d042dd56f1db613d1da861a32be5cf17018800012e34549ab2ebb5ed87dc3424
 
 name:           firelink
 version:        0.2.0.0
@@ -34,6 +34,7 @@ library
       FireLink.BackEnd.InstructionCodeGenerator
       FireLink.BackEnd.LivenessAnalyser
       FireLink.BackEnd.Optimizer
+      FireLink.BackEnd.Utils
       FireLink.FrontEnd.Errors
       FireLink.FrontEnd.FrontEndCompiler
       FireLink.FrontEnd.Grammar

--- a/package.yaml
+++ b/package.yaml
@@ -28,6 +28,7 @@ dependencies:
 - mtl
 - containers
 - sort
+- optparse-applicative
 
 library:
   source-dirs: [src, src/tac]

--- a/src/FireLink.hs
+++ b/src/FireLink.hs
@@ -12,7 +12,8 @@ import qualified Data.Set                            as Set
 import           FireLink.BackEnd.BackEndCompiler    (backend)
 import           FireLink.BackEnd.CodeGenerator      (TAC (..), TACSymEntry)
 import           FireLink.BackEnd.FlowGraphGenerator (NumberedBlock)
-import           FireLink.BackEnd.LivenessAnalyser   (InterferenceGraph, def)
+import           FireLink.BackEnd.LivenessAnalyser   (InterferenceGraph, def,
+                                                      use)
 import           FireLink.FrontEnd.Errors
 import           FireLink.FrontEnd.FrontEndCompiler
 import qualified FireLink.FrontEnd.SymTable          as ST
@@ -217,6 +218,10 @@ printBasicBlocks = mapM_ printBlock
             unless (Set.null d) $ do
                 putStrLn $ red ++ "Definitions of block " ++ show i ++ nocolor
                 putStrLn $ intercalate "\n" $ map show $ Set.toList d
+            let u = use $ snd nb
+            unless (Set.null u) $ do
+                putStrLn $ red ++ "Variable uses of block " ++ show i ++ nocolor
+                putStrLn $ intercalate "\n" $ map show $ Set.toList u
 
 
 printInterferenceGraph :: Map.Map Int TACSymEntry -> G.Graph -> IO ()

--- a/src/FireLink.hs
+++ b/src/FireLink.hs
@@ -291,7 +291,7 @@ compile program args = do
         Left e -> uncurry handleCompileError e >> exitFailure
         Right (ast, symTable, tokens) -> do
             ((numberedBlocks, flowGraph), interferenceGraph, registerAssignment) <- backend ast (ST.stDict symTable)
-            unless (anyArg args) $ do
+            when (anyArg args) $ do
                 -- Default behavior: print everything
                 putStrLn "\nFireLink: Printing SymTable"
                 prettyPrintSymTable symTable
@@ -306,13 +306,13 @@ compile program args = do
                 putStrLn "FireLink: printing register assignment with interference graph"
                 printInterferenceGraph'' interferenceGraph registerAssignment
                 return ()
-            unless (showSymTable args && showProgram args) $ prettyPrintSymTable symTable >> printProgram True tokens
-            unless (showSymTable args) $ prettyPrintSymTable symTable
-            unless (showProgram args) $ printProgram True tokens
-            unless (showTac args) $ printTacCode $ concatMap snd numberedBlocks
-            unless (showBlocks args) $ printBasicBlocks numberedBlocks
-            unless (showGraph args) $ printFlowGraph flowGraph
-            unless (showRegisterAssignment args) $ printInterferenceGraph'' interferenceGraph registerAssignment
+            when (showSymTable args && showProgram args) $ prettyPrintSymTable symTable >> printProgram True tokens
+            when (showSymTable args) $ prettyPrintSymTable symTable
+            when (showProgram args) $ printProgram True tokens
+            when (showTac args) $ printTacCode $ concatMap snd numberedBlocks
+            when (showBlocks args) $ printBasicBlocks numberedBlocks
+            when (showGraph args) $ printFlowGraph flowGraph
+            when (showRegisterAssignment args) $ printInterferenceGraph'' interferenceGraph registerAssignment
             exitSuccess
 
 anyArg :: CommandLineArgs -> Bool
@@ -327,6 +327,7 @@ data CommandLineArgs = CommandLineArgs
     , showGraph :: Bool
     , showRegisterAssignment :: Bool
     }
+    deriving Show
 
 commandLineParser :: Parser CommandLineArgs
 commandLineParser =

--- a/src/FireLink.hs
+++ b/src/FireLink.hs
@@ -268,14 +268,19 @@ printInterferenceGraph' (vertexMap, graph) = do
     let vs = G.vertices graph
     let es = G.edges graph
     putStrLn $ bold ++ "Graph (" ++ (show . length) vs ++ " variables, " ++ (show . length) es ++ " interferences)" ++ nocolor
-    let groupedEdges = groupBy (\a b -> fst a == fst b) es
-    mapM_ printEdges groupedEdges
+    mapM_ printEdges vs
     where
-        printEdges :: [G.Edge] -> IO ()
-        printEdges es = do
-            let origin = (fst . head) es
-            let originName = show $ vertexMap Map.! origin
-            let destinies = map snd es
+        successors :: G.Vertex -> [G.Vertex]
+        successors vertex =
+            let graphEdges = G.edges graph
+                outgoingEdges = filter ((== vertex) . fst) graphEdges
+                successors' = map snd outgoingEdges
+            in successors'
+
+        printEdges :: G.Vertex -> IO ()
+        printEdges v = do
+            let originName = show $ vertexMap Map.! v
+            let destinies = successors v
             putStrLn $ bold ++ originName ++ nocolor ++ " -> " ++ printDestinies destinies
 
         printDestinies :: [Int] -> String

--- a/src/FireLink.hs
+++ b/src/FireLink.hs
@@ -8,10 +8,11 @@ import qualified Data.Graph                          as G
 import           Data.List                           (groupBy, intercalate)
 import qualified Data.Map                            as Map
 import           Data.Maybe                          (fromJust)
+import qualified Data.Set                            as Set
 import           FireLink.BackEnd.BackEndCompiler    (backend)
 import           FireLink.BackEnd.CodeGenerator      (TAC (..), TACSymEntry)
 import           FireLink.BackEnd.FlowGraphGenerator (NumberedBlock)
-import           FireLink.BackEnd.LivenessAnalyser   (InterferenceGraph)
+import           FireLink.BackEnd.LivenessAnalyser   (InterferenceGraph, def)
 import           FireLink.FrontEnd.Errors
 import           FireLink.FrontEnd.FrontEndCompiler
 import qualified FireLink.FrontEnd.SymTable          as ST
@@ -212,6 +213,11 @@ printBasicBlocks = mapM_ printBlock
                 putStrLn $ red ++ "Interference Graph for Block " ++ show i ++ nocolor
                 printInterferenceGraph (Map.fromList $ map (\(x, y) -> (y, x)) $ Map.toList msi) g
                 putStrLn ""
+            let d = def $ snd nb
+            unless (Set.null d) $ do
+                putStrLn $ red ++ "Definitions of block " ++ show i ++ nocolor
+                putStrLn $ intercalate "\n" $ map show $ Set.toList d
+
 
 printInterferenceGraph :: Map.Map Int TACSymEntry -> G.Graph -> IO ()
 printInterferenceGraph msi g = do

--- a/src/FireLink.hs
+++ b/src/FireLink.hs
@@ -2,7 +2,7 @@ module FireLink (
     firelink
 ) where
 
-import           Control.Monad                      (unless)
+import           Control.Monad                      (unless, when)
 import qualified Control.Monad.RWS                  as RWS
 import qualified Data.Graph                         as G
 import           Data.List                          (groupBy, intercalate)
@@ -20,6 +20,7 @@ import           System.Environment                 (getArgs)
 import           System.Exit                        (exitFailure, exitSuccess)
 import           System.FilePath                    (takeExtension)
 
+import           Data.Map.Internal.Debug            (showTree)
 import           Data.Semigroup                     ((<>))
 import           Options.Applicative
 import           System.IO                          (IOMode (..), hGetContents,
@@ -246,6 +247,10 @@ printInterferenceGraph'' (vertexMap, graph) registerAssignment = do
     let vs = G.vertices graph
     let es = G.edges graph
     putStrLn $ bold ++ "Graph (" ++ (show . length) vs ++ " variables, " ++ (show . length) es ++ " interferences)" ++ nocolor
+    -- putStrLn "vertexMap"
+    -- putStrLn $ showTree vertexMap
+    -- putStrLn "registerAssignment"
+    -- putStrLn $ showTree registerAssignment
     mapM_ printEdges vs
     checkValidity vs
     where
@@ -287,6 +292,7 @@ printInterferenceGraph'' (vertexMap, graph) registerAssignment = do
 compile :: String -> CommandLineArgs -> IO ()
 compile program args = do
     compilerResult <- frontEnd program
+    print args
     case compilerResult of
         Left e -> uncurry handleCompileError e >> exitFailure
         Right (ast, symTable, tokens) -> do

--- a/src/FireLink.hs
+++ b/src/FireLink.hs
@@ -9,7 +9,7 @@ import           Data.List                           (groupBy, intercalate)
 import qualified Data.Map                            as Map
 import           Data.Maybe                          (fromJust)
 import           FireLink.BackEnd.BackEndCompiler    (backend)
-import           FireLink.BackEnd.CodeGenerator      (TAC (..))
+import           FireLink.BackEnd.CodeGenerator      (TAC (..), TACSymEntry)
 import           FireLink.BackEnd.FlowGraphGenerator (NumberedBlock)
 import           FireLink.BackEnd.LivenessAnalyser   (InterferenceGraph)
 import           FireLink.FrontEnd.Errors
@@ -213,7 +213,7 @@ printBasicBlocks = mapM_ printBlock
                 printInterferenceGraph (Map.fromList $ map (\(x, y) -> (y, x)) $ Map.toList msi) g
                 putStrLn ""
 
-printInterferenceGraph :: Map.Map Int String -> G.Graph -> IO ()
+printInterferenceGraph :: Map.Map Int TACSymEntry -> G.Graph -> IO ()
 printInterferenceGraph msi g = do
     let es = G.edges g
     let groupedEdges = groupBy (\a b -> fst a == fst b) es
@@ -225,8 +225,8 @@ printInterferenceGraph msi g = do
             let originName = fromJust $ Map.lookup origin msi
             let destinies = map snd es
             let destiniesNames = map (\x -> fromJust $ Map.lookup x msi) destinies
-            let joinedDestiniesNames = intercalate ", " destiniesNames
-            putStrLn $ bold ++ originName ++ nocolor ++ " -> " ++ joinedDestiniesNames
+            let joinedDestiniesNames = intercalate ", " $ map show destiniesNames
+            putStrLn $ bold ++ show originName ++ nocolor ++ " -> " ++ joinedDestiniesNames
 
 printFlowGraph :: G.Graph -> IO ()
 printFlowGraph g = do

--- a/src/FireLink/BackEnd/BackEndCompiler.hs
+++ b/src/FireLink/BackEnd/BackEndCompiler.hs
@@ -13,9 +13,7 @@ import           FireLink.BackEnd.CodeGenerator            (CodeGenState (..),
                                                             genCode,
                                                             initialState)
 import           FireLink.BackEnd.FlowGraphGenerator       (NumberedBlock,
-                                                            findBasicBlocks,
-                                                            generateFlowGraph,
-                                                            numberTACs)
+                                                            generateFlowGraph)
 import           FireLink.BackEnd.InstructionCodeGenerator
 import           FireLink.BackEnd.LivenessAnalyser
 import           FireLink.BackEnd.Optimizer                (optimize)
@@ -28,11 +26,10 @@ backend program dictionary = do
     (_, finalState, code) <- runRWST (genCode program) dictionary initialState
     let postProcessedCode = fillEmptyTemporals (cgsTemporalsToReplace finalState) code
     let optimizedCode = optimize postProcessedCode
-    let basicBlocks = findBasicBlocks $ numberTACs optimizedCode
+    let (numberedBlocks, flowGraph) = generateFlowGraph optimizedCode
+    let basicBlocks = map snd numberedBlocks
     let interferenceGraphs = map generateInterferenceGraph basicBlocks
-    let numberedBlocks = zip [0..] basicBlocks
     let blocksWithInterGraphs = zip numberedBlocks interferenceGraphs
-    let flowGraph = generateFlowGraph optimizedCode
 
     return (optimizedCode, blocksWithInterGraphs, flowGraph)
     where

--- a/src/FireLink/BackEnd/BackEndCompiler.hs
+++ b/src/FireLink/BackEnd/BackEndCompiler.hs
@@ -7,6 +7,7 @@ import           Control.Monad.State
 import           Data.Graph                                (Graph)
 import           Data.List                                 (intercalate)
 import           FireLink.BackEnd.CodeGenerator            (CodeGenState (..),
+                                                            SimpleType (..),
                                                             TAC (..),
                                                             TACSymEntry (..),
                                                             genCode,
@@ -20,7 +21,6 @@ import           FireLink.BackEnd.LivenessAnalyser
 import           FireLink.BackEnd.Optimizer                (optimize)
 import           FireLink.FrontEnd.Grammar                 (Program (..))
 import           FireLink.FrontEnd.SymTable                (Dictionary (..))
-import           FireLink.FrontEnd.TypeChecking            (Type (..))
 import           TACType
 
 backend :: Program -> Dictionary -> IO ([TAC], [(NumberedBlock, InterferenceGraph)], Graph)
@@ -48,7 +48,7 @@ backend program dictionary = do
                         ThreeAddressCode
                             Assign
                             (Just (Id $ fst t))
-                            (Just $ Constant (show $ snd t, BigIntT))
+                            (Just $ Constant (show $ snd t, BigIntTAC))
                             Nothing
             _ -> tac
 

--- a/src/FireLink/BackEnd/BackEndCompiler.hs
+++ b/src/FireLink/BackEnd/BackEndCompiler.hs
@@ -35,10 +35,10 @@ backend program dictionary = do
     let interferenceGraphs = map generateInterferenceGraph basicBlocks
     let blocksWithInterGraphs = zip numberedBlocks interferenceGraphs
     let livenessAnalysisResult = livenessAnalyser flowGraph
-    let interferenceGraph' = generateInterferenceGraph' flowGraph
+    let (interferenceGraph', _) = generateInterferenceGraph' flowGraph
 
     let (initialRegisterAssignment, flowGraph'@(newNumberedBlocks, _)) = initialStep flowGraph dictionary
-    let interferenceGraph'' = generateInterferenceGraph' flowGraph'
+    let (interferenceGraph'', _) = generateInterferenceGraph' flowGraph'
 
 
     putStrLn "Before first step"

--- a/src/FireLink/BackEnd/BackEndCompiler.hs
+++ b/src/FireLink/BackEnd/BackEndCompiler.hs
@@ -36,7 +36,7 @@ backend program dictionary = do
     let optimizedCode = optimize postProcessedCode
     let flowGraph@(numberedBlocks, graph) = generateFlowGraph optimizedCode
 
-    let (registerAssignment, finalFlowGraph) = run flowGraph dictionary
+    (registerAssignment, finalFlowGraph) <- run flowGraph dictionary
     let (interferenceGraph'', _) = generateInterferenceGraph' finalFlowGraph
     return (finalFlowGraph, interferenceGraph'', registerAssignment)
     where

--- a/src/FireLink/BackEnd/BackEndCompiler.hs
+++ b/src/FireLink/BackEnd/BackEndCompiler.hs
@@ -25,6 +25,8 @@ import           FireLink.FrontEnd.SymTable                 (Dictionary (..))
 import           FireLink.Utils
 import           TACType
 
+import           Data.Map.Internal.Debug                    (showTree)
+
 backend :: Program -> Dictionary -> IO ([TAC], [(NumberedBlock, InterferenceGraph)], Graph, InterferenceGraph)
 backend program dictionary = do
     (_, finalState, code) <- runRWST (genCode program) dictionary initialState
@@ -37,23 +39,8 @@ backend program dictionary = do
     let livenessAnalysisResult = livenessAnalyser flowGraph
     let (interferenceGraph', _) = generateInterferenceGraph' flowGraph
 
-    let (initialRegisterAssignment, flowGraph'@(newNumberedBlocks, _)) = initialStep flowGraph dictionary
-    let (interferenceGraph'', _) = generateInterferenceGraph' flowGraph'
-
-
-    putStrLn "Before first step"
-    printBasicBlocks numberedBlocks
-    putStrLn "After first step"
-    printBasicBlocks newNumberedBlocks
-    mapM_ print livenessAnalysisResult
-
-    putStrLn "Interference grahp before code manipulation assignment"
-    printInterferenceGraph' interferenceGraph'
-
-    putStrLn "Initial register assignment"
-    printRegisterAssignment initialRegisterAssignment
-    putStrLn "Interference grahp after codemanipulation assignment"
-    printInterferenceGraph' interferenceGraph''
+    let (registerAssignment, finalNumberedBlock) = run flowGraph dictionary
+    putStrLn $ showTree registerAssignment
     return (optimizedCode, blocksWithInterGraphs, graph, interferenceGraph')
     where
         fillEmptyTemporals :: [(TACSymEntry, Int)] -> [TAC] -> [TAC]

--- a/src/FireLink/BackEnd/BackEndCompiler.hs
+++ b/src/FireLink/BackEnd/BackEndCompiler.hs
@@ -42,7 +42,7 @@ backend program dictionary = do
     printBasicBlocks numberedBlocks
     putStrLn "After first step"
     printBasicBlocks newNumberedBlocks
-    -- mapM_ print livenessAnalysisResult
+    mapM_ print livenessAnalysisResult
     return (optimizedCode, blocksWithInterGraphs, graph, interferenceGraph')
     where
         fillEmptyTemporals :: [(TACSymEntry, Int)] -> [TAC] -> [TAC]

--- a/src/FireLink/BackEnd/CodeGenerator.hs
+++ b/src/FireLink/BackEnd/CodeGenerator.hs
@@ -146,7 +146,7 @@ isProgramEnd :: Operation -> Bool
 isProgramEnd = flip elem [Exit, Abort]
 
 isUnconditionalJump :: Operation -> Bool
-isUnconditionalJump = flip elem [GoTo, Call, Return]
+isUnconditionalJump = flip elem [GoTo, Return]
 
 isConditionalJump :: Operation -> Bool
 isConditionalJump = flip elem [If, Eq, Neq, Gt, Lt, Gte, Lte]

--- a/src/FireLink/BackEnd/CodeGenerator.hs
+++ b/src/FireLink/BackEnd/CodeGenerator.hs
@@ -1,7 +1,7 @@
 module FireLink.BackEnd.CodeGenerator where
 
 import           Control.Monad.RWS          (RWST (..), ask, get, put, tell)
-import           Data.Map.Strict            as Map
+import qualified Data.Map.Strict            as Map
 import qualified FireLink.FrontEnd.Grammar  as G (Id (..))
 import           FireLink.FrontEnd.SymTable (Dictionary (..),
                                              DictionaryEntry (..), Extra (..),
@@ -38,7 +38,24 @@ type Offset = Int
 data TACSymEntry
     = TACTemporal String Offset
     | TACVariable DictionaryEntry Offset
-    deriving Eq
+
+instance Eq TACSymEntry where
+    -- following works because temporal variables are unique, so we can safely compare just the name
+    TACTemporal s _ == TACTemporal s' _ = s == s'
+    TACVariable entry _ == TACVariable entry' _ = name entry == name entry' && scope entry == scope entry'
+    _ == _ = False
+
+-- Although "TACSymEntry" doesn't really have a total order, "Data.Map" and "Data.Set" operations with this
+-- data type requires to instance "Ord"
+-- Rules are simple though:
+-- 1. Temporals *always* go before program variables
+-- 2. Temporals comparisons use their actual string representations
+-- 3. Variables comparisons use their (name, scope)
+instance Ord TACSymEntry where
+    TACTemporal _ _ <= TACVariable _ _ = True
+    TACTemporal s _ <= TACTemporal s' _ = s <= s'
+    TACVariable entry _ <= TACVariable entry' _ = (name entry, scope entry) <= (name entry', scope entry')
+    _ <= _ = False
 
 getTACSymEntryOffset :: TACSymEntry -> Int
 getTACSymEntryOffset (TACTemporal _ o) = o
@@ -203,3 +220,12 @@ typeWidth t = do
 isId :: OperandType -> Bool
 isId (Id _) = True
 isId _      = False
+
+-- | Takes a list of "OperandTypes" and returns only the "TACSymEntry", similar to
+-- | "Data.Maybe.catMaybes"
+catTACSymEntries :: [OperandType] -> [TACSymEntry]
+catTACSymEntries = foldr f []
+    where
+        f :: OperandType -> [TACSymEntry] -> [TACSymEntry]
+        f (Id s) l = s : l
+        f _ l      = l

--- a/src/FireLink/BackEnd/CodeGenerator.hs
+++ b/src/FireLink/BackEnd/CodeGenerator.hs
@@ -63,7 +63,7 @@ getTACSymEntryOffset (TACVariable _ o) = o
 
 instance SymEntryCompatible TACSymEntry where
     getSymID (TACTemporal s o)          = "(" ++ s ++ ")base[" ++ show o ++ "]"
-    getSymID (TACVariable entry offset) = "(" ++ name entry ++ ")base[" ++ show offset ++ "]"
+    getSymID (TACVariable entry offset) = "(" ++ name entry ++ ":" ++ show (scope entry) ++ ")base[" ++ show offset ++ "]"
 
 instance Show TACSymEntry where
     show = getSymID

--- a/src/FireLink/BackEnd/FlowGraphGenerator.hs
+++ b/src/FireLink/BackEnd/FlowGraphGenerator.hs
@@ -1,5 +1,6 @@
 module FireLink.BackEnd.FlowGraphGenerator(
-    generateFlowGraph, BasicBlock, NumberedBlock
+    generateFlowGraph, BasicBlock, NumberedBlock, FlowGraph,
+    entryVertex, exitVertex
 ) where
 
 import           Data.Char                      (isDigit)
@@ -10,6 +11,7 @@ import           FireLink.BackEnd.CodeGenerator (OperandType (..), TAC (..),
                                                  isConditionalJump, isJump,
                                                  isProgramEnd,
                                                  isUnconditionalJump)
+import           FireLink.BackEnd.Utils
 import           TACType
 
 -- | A numbered instruction (the number being a unique identifier within some context)
@@ -34,7 +36,8 @@ type NumberedBlocks = [NumberedBlock]
 type Edges = [Edge]
 
 -- | FlowGraph representation. First tuple contains the basic blocks, with their respective number
--- | Second tuple position contains the graph with the basic block numbers as edges
+-- | Second tuple position contains the graph with the basic block numbers as edges.
+-- | Graph nodes includes -1 as entry node and `length numberedBlocks` as exit node
 type FlowGraph = (NumberedBlocks, Graph)
 
 -- | Generates and returns the flow graph
@@ -51,6 +54,14 @@ generateFlowGraph code =
         edges = entryEdge : jumpEdges ++ fallEdges
         graph = buildG (-1, length numberedBlocks) edges
     in  (numberedBlocks, graph)
+
+-- | Helper to centralize what value is associated with flow graph entryVertex
+entryVertex :: FlowGraph -> Vertex
+entryVertex = const (-1)
+
+-- | Same for exitVertex
+exitVertex :: FlowGraph -> Vertex
+exitVertex = length . fst
 
 -- | Given an integer that represents an EXIT vertex, and a
 -- | list of numbered blocks, returns a list of edges
@@ -163,9 +174,3 @@ numberTACs = numberList
 numberBlocks :: BasicBlocks -> NumberedBlocks
 numberBlocks = numberList
 
--- | Given a list, returns a list of pairs in which
--- | each first component is an unique integer, and each second
--- | component is a (now uniquely identified) element of the first list,
--- | in the original order
-numberList :: [a] -> [(Int, a)]
-numberList = zip [0..]

--- a/src/FireLink/BackEnd/FlowGraphGenerator.hs
+++ b/src/FireLink/BackEnd/FlowGraphGenerator.hs
@@ -40,7 +40,7 @@ generateFlowGraph code =
         numberedBlocks = numberBlocks basicBlocks
         fallEdges = getFallEdges numberedBlocks
         entryEdge = (-1, 0) -- ENTRY
-        exitNode = (length numberedBlocks) -- EXIT
+        exitNode = length numberedBlocks -- EXIT
         jumpEdges = getJumpEdges numberedBlocks exitNode
         edges = entryEdge : jumpEdges ++ fallEdges
         graph = buildG (-1, length numberedBlocks) edges
@@ -67,7 +67,7 @@ getJumpEdges code vExit = foldr findAllJumpEdges [] code
                 else if op == Return then
                     let (_, fcb) = findFunctionDefBlock i code
                         ThreeAddressCode _ _ mL _ = head fcb
-                    in  es ++ (map (\x -> (i, x)) (getCallsToLabel mL code))
+                    in  es ++ map (\x -> (i, x)) (getCallsToLabel mL code)
                 else es
 
         findDestinyBlock :: Maybe OperandType -> NumberedBlocks -> NumberedBlock
@@ -143,11 +143,11 @@ findBlockLeaders ts = nub $ head ts : findBlockLeaders' ts
         findBlockLeaders' (x:ys@(y:_)) = [y | isJumpTac x] ++ [x | isJumpDestiny x] ++ findBlockLeaders' ys
 
         isJumpTac :: NumberedTAC -> Bool
-        isJumpTac (_, (ThreeAddressCode op _ _ _)) = isJump op
+        isJumpTac (_, ThreeAddressCode op _ _ _) = isJump op
 
         isJumpDestiny :: NumberedTAC -> Bool
-        isJumpDestiny (_, (ThreeAddressCode NewLabel _ (Just _) _)) = True
-        isJumpDestiny _                                             = False
+        isJumpDestiny (_, ThreeAddressCode NewLabel _ (Just _) _) = True
+        isJumpDestiny _                                           = False
 
 -- | Type-binding application of numberList for a code block
 numberTACs :: [TAC] -> NumberedTACs

--- a/src/FireLink/BackEnd/FlowGraphGenerator.hs
+++ b/src/FireLink/BackEnd/FlowGraphGenerator.hs
@@ -1,4 +1,6 @@
-module FireLink.BackEnd.FlowGraphGenerator where
+module FireLink.BackEnd.FlowGraphGenerator(
+    generateFlowGraph, BasicBlock, NumberedBlock
+) where
 
 import           Data.Char                      (isDigit)
 import           Data.Graph
@@ -31,9 +33,13 @@ type NumberedBlocks = [NumberedBlock]
 -- | Semantic shortcut for a list of edges
 type Edges = [Edge]
 
+-- | FlowGraph representation. First tuple contains the basic blocks, with their respective number
+-- | Second tuple position contains the graph with the basic block numbers as edges
+type FlowGraph = (NumberedBlocks, Graph)
+
 -- | Generates and returns the flow graph
 -- | that correspond to a given list of TAC instructions.
-generateFlowGraph :: [TAC] -> Graph
+generateFlowGraph :: [TAC] -> FlowGraph
 generateFlowGraph code =
     let numberedInstructions = numberTACs code
         basicBlocks = findBasicBlocks numberedInstructions
@@ -44,7 +50,7 @@ generateFlowGraph code =
         jumpEdges = getJumpEdges numberedBlocks exitNode
         edges = entryEdge : jumpEdges ++ fallEdges
         graph = buildG (-1, length numberedBlocks) edges
-    in  graph
+    in  (numberedBlocks, graph)
 
 -- | Given an integer that represents an EXIT vertex, and a
 -- | list of numbered blocks, returns a list of edges

--- a/src/FireLink/BackEnd/FlowGraphGenerator.hs
+++ b/src/FireLink/BackEnd/FlowGraphGenerator.hs
@@ -81,13 +81,6 @@ getJumpEdges code vExit = foldr findAllJumpEdges [] code
                 then let (j, _) = findDestinyBlock dJ code
                     in  (i, j) : es
                 else if isProgramEnd op then (i, vExit) : es
-                else if op == Call then
-                    let (j, _) = findDestinyBlock dC code
-                    in (i, j) : es
-                else if op == Return then
-                    let (_, fcb) = findFunctionDefBlock i code
-                        ThreeAddressCode _ _ mL _ = head fcb
-                    in  es ++ map (\x -> (i, x)) (getCallsToLabel mL code)
                 else es
 
         findDestinyBlock :: Maybe OperandType -> NumberedBlocks -> NumberedBlock

--- a/src/FireLink/BackEnd/LivenessAnalyser.hs
+++ b/src/FireLink/BackEnd/LivenessAnalyser.hs
@@ -12,6 +12,9 @@ import           FireLink.BackEnd.CodeGenerator
 import           FireLink.BackEnd.FlowGraphGenerator
 import           TACType
 
+-- | A pair representing an unique point in a program. Its meaning is to hold (blockIds, instructionIndex)
+type ProgramPoint = (Int, Int)
+
 -- | A set of live variables at a given time, represented by their unique string name
 type LiveVariables = Set.Set String
 

--- a/src/FireLink/BackEnd/LivenessAnalyser.hs
+++ b/src/FireLink/BackEnd/LivenessAnalyser.hs
@@ -16,14 +16,6 @@ import           FireLink.BackEnd.FlowGraphGenerator
 import           FireLink.BackEnd.Utils
 import           TACType
 
--- | Given a basic block, builds and returns a list of the string-representation
--- | of all the variables used in the program (including temporals)
-getAllVariables :: BasicBlock -> [TACSymEntry]
-getAllVariables = foldr getVariables []
-    where
-        getVariables :: TAC -> [TACSymEntry] -> [TACSymEntry]
-        getVariables (ThreeAddressCode _ a b c) xs = xs ++ catTACSymEntries (catMaybes [a, b, c])
-
 -- | Operations that consists of an assignment of a value to a lvalue
 -- | TODO: Add pointer operations here when their implementation is ready
 assignableOperations :: [Operation]
@@ -249,7 +241,7 @@ generateInterferenceGraph' flowGraph'@(numberedBlocks, flowGraph) =
         outN = Set.map vertexMapLookup
 
         programVariables :: Set.Set TACSymEntry
-        programVariables = Set.unions $ map (Set.fromList . getAllVariables . snd) numberedBlocks
+        programVariables = getProgramVariables numberedBlocks
 
         interferenceGraphVertexMap :: Map.Map TACSymEntry Graph.Vertex
         interferenceGraphVertexMap = Map.fromList $ zip (Set.toList programVariables) [0..]

--- a/src/FireLink/BackEnd/LivenessAnalyser.hs
+++ b/src/FireLink/BackEnd/LivenessAnalyser.hs
@@ -12,31 +12,6 @@ import           FireLink.BackEnd.CodeGenerator
 import           FireLink.BackEnd.FlowGraphGenerator
 import           TACType
 
--- | A pair representing an unique point in a program. Its meaning is to hold (blockIds, instructionIndex)
-type ProgramPoint = (Int, Int)
-
--- | A set of live variables at a given time, represented by their unique string name
-type LiveVariables = Set.Set TACSymEntry
-
--- | A map that points a variable to the instruction it's next used in (or none)
-type NextUseMap = Map.Map TACSymEntry (Maybe Int)
-
--- | An object containing a given point's next use information: live variables and next-use information
-data NextUseInfo = NextUseInfo {
-    nuiLiveVars :: !LiveVariables,
-    nuiNextUse :: !NextUseMap
-}
-instance Show NextUseInfo where
-    show NextUseInfo {nuiLiveVars=vs, nuiNextUse=us } =
-        "LiveVars: " ++ show (Set.toList vs) ++ ", NextUse: " ++ show (Map.toList us)
-
--- | Our StateT that will progressively fetch next use info on our basic block
-type NextUseState = StateT NextUseInfo IO
-
--- | A list of pairs of TAC instructions with their respective next use info.
--- | Basically, a basic block (no pun intended) with each instruction tagged with such info.
-type BlockLiveness = [(TAC, NextUseInfo)]
-
 -- | A map that matches variable names to integer representations,
 -- | and a graph that matches such representations' mutual interference
 type InterferenceGraph = (Map.Map TACSymEntry Int, Graph)

--- a/src/FireLink/BackEnd/LivenessAnalyser.hs
+++ b/src/FireLink/BackEnd/LivenessAnalyser.hs
@@ -24,19 +24,45 @@ getAllVariables = foldr getVariables []
         getVariables :: TAC -> [TACSymEntry] -> [TACSymEntry]
         getVariables (ThreeAddressCode _ a b c) xs = xs ++ catTACSymEntries (catMaybes [a, b, c])
 
+-- | Operations that consists of an assignment of a value to a lvalue
+-- | TODO: Add pointer operations here when their implementation is ready
+assignableOperations :: [Operation]
+assignableOperations = [Assign, Add, Minus, Sub, Mult, Div, Mod, Get, Call, Set]
+
 -- | Calculate variable definitions of a basic block, used by data-flow analysis algorithm for liveness analysis
 -- | Mathematically, def[B] = union of def[n] for n in B.indices
 def :: BasicBlock -> Set.Set TACSymEntry
 def = foldr def' Set.empty
     where
-        assignableOperations :: [Operation]
-        assignableOperations = [Assign, Add, Minus, Sub, Mult, Div, Mod, Get, Call]
-
         def' :: TAC -> Set.Set TACSymEntry -> Set.Set TACSymEntry
-        def' (ThreeAddressCode op (Just (Id v)) _ _) s
-            | op `elem` assignableOperations = Set.insert v s
-            | otherwise = s
-        def' _ s = s
+        def' tac s = s `Set.union` def1 tac
+
+-- | Calculates definition for a single three-address code instruction. Basically, the left side of an instruction
+-- | that assigns a variable.
+def1 :: TAC -> Set.Set TACSymEntry
+def1 :: TAC -> Set.Set TACSymEntry
+def1 (ThreeAddressCode op (Just (Id v)) _ _) s
+    | op `elem` assignableOperations = Set.singleton v
+    | otherwise = Set.empty
+
+-- | Read will end setting a value to its parameter
+def1 (ThreeAddressCode Read _ (Just (Id v)) _) = Set.singleton v
+def1 _ s = Set.empty
+
+-- | Calculate used variables in a basic block prior to any definition of the same variable inside the
+-- | same block
+use :: BasicBlock -> Set.Set TACSymEntry
+use = foldr use' Set.empty
+    where
+        use' :: TAC -> Set.Set TACSymEntry -> Set.Set TACSymEntry
+        use' tac set = error ""
+
+-- | Calculate used variables in a single instruction. That is, their operands
+-- | TODO: review operations on the `otherwise` branch to see if the used values are actually ok
+use1 :: TAC -> Set.Set TACSymEntry
+use1 (ThreeAddressCode op u v w)
+    | op `elem` assignableOperations = Set.fromList $ catTACSymEntries $ catMaybes [v, w]
+    | otherwise = Set.fromList $ catTACSymEntries $ catMaybes [u, v, w]
 
 -- | Given a basic block, generates the interference graph
 -- | by checking all of its instructions, one by one, as an undirected

--- a/src/FireLink/BackEnd/LivenessAnalyser.hs
+++ b/src/FireLink/BackEnd/LivenessAnalyser.hs
@@ -1,6 +1,6 @@
 module FireLink.BackEnd.LivenessAnalyser (
     def, use, generateInterferenceGraph, InterferenceGraph (..), livenessAnalyser,
-    generateInterferenceGraph', LineLiveVariables(..)
+    generateInterferenceGraph', LineLiveVariables(..), ProgramPoint
 ) where
 
 import           Control.Monad.State
@@ -71,8 +71,11 @@ use1 (ThreeAddressCode op u v w)
 -- | Semantic alias for Set.Set TACSymEntry
 type LiveVariables = Set.Set TACSymEntry
 
+-- | (block id, instruction index)
+type ProgramPoint = (Int, Int)
+
 data LineLiveVariables = LineLiveVariables
-    { llvInstrId :: !(Int, Int) -- ^ (Block id, instruction index)
+    { llvInstrId :: !ProgramPoint -- ^ Program point of this information
     , llvInLiveVariables :: !LiveVariables -- ^ live variables upon execution this block
     , llvOutLiveVariables :: !LiveVariables -- ^ live variables after execution this block
     }

--- a/src/FireLink/BackEnd/LivenessAnalyser.hs
+++ b/src/FireLink/BackEnd/LivenessAnalyser.hs
@@ -1,6 +1,6 @@
 module FireLink.BackEnd.LivenessAnalyser (
     def, use, generateInterferenceGraph, InterferenceGraph (..), livenessAnalyser,
-    generateInterferenceGraph'
+    generateInterferenceGraph', LineLiveVariables(..)
 ) where
 
 import           Control.Monad.State

--- a/src/FireLink/BackEnd/LivenessAnalyser.hs
+++ b/src/FireLink/BackEnd/LivenessAnalyser.hs
@@ -230,7 +230,7 @@ generateInterferenceGraph' flowGraph'@(numberedBlocks, flowGraph) =
                     o = outN out
                     tac = getTac instrId
                     res = d `Set.cartesianProduct` o
-                    in case tac of
+                    in Set.filter (uncurry (/=)) $ case tac of
                         ThreeAddressCode Assign (Just (Id v)) _ _ ->
                             let varId = vertexMapLookup v
                                 toDelete = d `Set.cartesianProduct` Set.singleton varId

--- a/src/FireLink/BackEnd/LivenessAnalyser.hs
+++ b/src/FireLink/BackEnd/LivenessAnalyser.hs
@@ -216,7 +216,7 @@ generateInterferenceGraph block =
 generateInterferenceGraph' :: FlowGraph -> InterferenceGraph
 generateInterferenceGraph' flowGraph'@(numberedBlocks, flowGraph) =
     ( Map.fromList $ map (\(i, j) -> (j, i)) $ Map.toList interferenceGraphVertexMap
-    , Graph.buildG (0, Set.size programVariables) interferenceGraphEdges)
+    , Graph.buildG (0, Set.size programVariables - 1) interferenceGraphEdges)
 
     where
         livenessAnalysis :: [LineLiveVariables]

--- a/src/FireLink/BackEnd/LivenessAnalyser.hs
+++ b/src/FireLink/BackEnd/LivenessAnalyser.hs
@@ -209,10 +209,11 @@ generateInterferenceGraph block =
 
 
 -- | Given a whole program, generates the interference graph by using liveness information
-generateInterferenceGraph' :: FlowGraph -> InterferenceGraph
+-- | Also returns the liveness analysis result.
+generateInterferenceGraph' :: FlowGraph -> (InterferenceGraph, [LineLiveVariables])
 generateInterferenceGraph' flowGraph'@(numberedBlocks, flowGraph) =
-    ( Map.fromList $ map (\(i, j) -> (j, i)) $ Map.toList interferenceGraphVertexMap
-    , Graph.buildG (0, Set.size programVariables - 1) interferenceGraphEdges)
+    ( (Map.fromList $ map (\(i, j) -> (j, i)) $ Map.toList interferenceGraphVertexMap
+    , Graph.buildG (0, Set.size programVariables - 1) interferenceGraphEdges), livenessAnalysis)
 
     where
         livenessAnalysis :: [LineLiveVariables]

--- a/src/FireLink/BackEnd/LivenessAnalyser.hs
+++ b/src/FireLink/BackEnd/LivenessAnalyser.hs
@@ -1,5 +1,6 @@
 module FireLink.BackEnd.LivenessAnalyser (
-    def, use, generateInterferenceGraph, InterferenceGraph (..), livenessAnalyser
+    def, use, generateInterferenceGraph, InterferenceGraph (..), livenessAnalyser,
+    generateInterferenceGraph'
 ) where
 
 import           Control.Monad.State

--- a/src/FireLink/BackEnd/LivenessAnalyser.hs
+++ b/src/FireLink/BackEnd/LivenessAnalyser.hs
@@ -1,6 +1,6 @@
 module FireLink.BackEnd.LivenessAnalyser (
     def, use, generateInterferenceGraph, InterferenceGraph (..), livenessAnalyser,
-    generateInterferenceGraph', LineLiveVariables(..), ProgramPoint
+    generateInterferenceGraph', LineLiveVariables(..), ProgramPoint, def1, use1
 ) where
 
 import           Control.Monad.State

--- a/src/FireLink/BackEnd/Optimizer.hs
+++ b/src/FireLink/BackEnd/Optimizer.hs
@@ -3,6 +3,7 @@ module FireLink.BackEnd.Optimizer (
 ) where
 
 import           FireLink.BackEnd.CodeGenerator (TAC (..))
+import           FireLink.BackEnd.Utils
 import           TACType
 
 -- | An 'Optimization' is a function that receives a list of TAC and
@@ -13,7 +14,7 @@ type Optimization = [TAC] -> [TAC]
 -- | stability is reached (i.e. until it converges)
 -- | (src: https://stackoverflow.com/a/23924238)
 optimize :: Optimization
-optimize = until =<< ((==) =<<) $ optimize'
+optimize = fixedPoint optimize'
 
 -- | Composes all valid optimizations into one function to be applied
 -- | to a generated three-address code list.

--- a/src/FireLink/BackEnd/RegisterAllocationProcess.hs
+++ b/src/FireLink/BackEnd/RegisterAllocationProcess.hs
@@ -12,10 +12,15 @@ avoid that the interference graph will have edges between their own variables.
 -}
 module FireLink.BackEnd.RegisterAllocationProcess where
 
-import qualified Data.Map                       as DM
-import           FireLink.BackEnd.CodeGenerator (TACSymEntry (..))
+import qualified Data.Map                            as DM
+import           FireLink.BackEnd.CodeGenerator      (TACSymEntry (..))
+import           FireLink.BackEnd.FlowGraphGenerator (FlowGraph (..))
 
 -- Semantic aliases
 type Register = Int
 type Color = Register
 type SymEntryRegisterMap = DM.Map TACSymEntry Color
+
+-- | Generate attempting final TAC assumming that we will have infinite registers i.e one register per actual variable
+initialStep :: FlowGraph -> (SymEntryRegisterMap, FlowGraph)
+initialStep (numberedBlocks, graph) = undefined

--- a/src/FireLink/BackEnd/RegisterAllocationProcess.hs
+++ b/src/FireLink/BackEnd/RegisterAllocationProcess.hs
@@ -10,11 +10,24 @@ https://cs.gmu.edu/~white/CS640/p98-chaitin.pdf
 all live variables at that moment are going to be "stored" before them. That is done to
 avoid that the interference graph will have edges between their own variables.
 -}
-module FireLink.BackEnd.RegisterAllocationProcess where
+module FireLink.BackEnd.RegisterAllocationProcess (initialStep) where
 
+import           Data.Char                           (isDigit)
 import qualified Data.Map                            as DM
-import           FireLink.BackEnd.CodeGenerator      (TACSymEntry (..))
-import           FireLink.BackEnd.FlowGraphGenerator (FlowGraph (..))
+import qualified Data.Set                            as DS
+import           Debug.Trace                         (trace)
+import           FireLink.BackEnd.CodeGenerator      (TAC (..),
+                                                      TACSymEntry (..))
+import           FireLink.BackEnd.FlowGraphGenerator (BasicBlock,
+                                                      FlowGraph (..),
+                                                      NumberedBlock,
+                                                      getProgramVariables)
+import           FireLink.BackEnd.LivenessAnalyser
+import           FireLink.FrontEnd.SymTable          (Dictionary (..),
+                                                      findArgsByFunName,
+                                                      getOffset)
+import qualified FireLink.FrontEnd.SymTable          as ST (DictionaryEntry (..))
+import           TACType
 
 -- Semantic aliases
 type Register = Int
@@ -22,5 +35,54 @@ type Color = Register
 type SymEntryRegisterMap = DM.Map TACSymEntry Color
 
 -- | Generate attempting final TAC assumming that we will have infinite registers i.e one register per actual variable
-initialStep :: FlowGraph -> (SymEntryRegisterMap, FlowGraph)
-initialStep (numberedBlocks, graph) = undefined
+-- | Also, before and after functions call live variables at that point will be saved to and loaded from memory respectively.
+-- | This is done to reduce the size of the interference graph, and because variables from different functions are not supposed
+-- | to interfere between them.
+initialStep :: FlowGraph -> Dictionary -> (SymEntryRegisterMap, FlowGraph)
+initialStep flowGraph@(numberedBlocks, graph) dict =
+    (variableRegisterMap, (preProcessCode, graph))
+    where
+        programVariables :: DS.Set TACSymEntry
+        programVariables = getProgramVariables numberedBlocks
+
+        -- | one for each actual variable
+        initialRegisters :: [Register]
+        initialRegisters = [0 .. DS.size programVariables - 1]
+
+        -- | Map for each tac to its initial register
+        variableRegisterMap :: SymEntryRegisterMap
+        variableRegisterMap = DM.fromList $ zip (DS.toList programVariables) initialRegisters
+
+        initialLivenessAnalysis :: [LineLiveVariables]
+        initialLivenessAnalysis = livenessAnalyser flowGraph
+
+        isTacLabelFun :: TAC -> Bool
+        isTacLabelFun (ThreeAddressCode NewLabel _ (Just (Label (l : _))) _) = l /= '_' && not (isDigit l)
+        isTacLabelFun _ = False
+
+        preProcessCode :: [NumberedBlock]
+        preProcessCode = map go numberedBlocks
+
+        go :: NumberedBlock -> NumberedBlock
+        go (index, block) = (index, concatMap go' block)
+
+        getFunctionArguments :: String -> [TACSymEntry]
+        getFunctionArguments funName =
+            let dictEntryArguments = findArgsByFunName funName dict in
+                map (\entry -> TACVariable entry (getOffset entry)) dictEntryArguments
+
+        go' :: TAC -> [TAC]
+        -- after generating code for labels, we need to load the used-arguments to their registers.
+        -- if a var is not in the variableRegisterMap then it is not used in the program i.e. we can
+        -- skip its load
+        go' tac@(ThreeAddressCode NewLabel _ (Just (Label funName)) _) =
+            if isTacLabelFun tac then
+                let args = getFunctionArguments funName
+                    loadTacsSet = map (\tacSymEntry ->
+                        case variableRegisterMap DM.!? tacSymEntry of
+                            Nothing -> []
+                            Just _ -> [ThreeAddressCode Load (Just (Id tacSymEntry)) Nothing Nothing]) args
+                    loadTacs = concat loadTacsSet in
+                        tac : loadTacs
+            else [tac]
+        go' tac = [tac]

--- a/src/FireLink/BackEnd/RegisterAllocationProcess.hs
+++ b/src/FireLink/BackEnd/RegisterAllocationProcess.hs
@@ -83,10 +83,12 @@ initialStep flowGraph@(numberedBlocks, graph) dict =
         go' :: (ProgramPoint, TAC) -> [TAC]
         -- If we find a function call, we need to store all live-variables at that point
         go' (programPoint, tac@(ThreeAddressCode Call _ _ _)) =
-            let liveVariables = llvInLiveVariables $ getLivenessIn programPoint
+            let liveVariablesInOut = getLivenessIn programPoint
                 storeTacs = map (\tacSymEntry ->
-                    ThreeAddressCode Store (Just (Id tacSymEntry)) Nothing Nothing) $ DS.toList liveVariables
-                in storeTacs ++ [tac]
+                    ThreeAddressCode Store (Just (Id tacSymEntry)) Nothing Nothing) $ DS.toList $ llvInLiveVariables liveVariablesInOut
+                loadTacs = map (\tacSymEntry ->
+                    ThreeAddressCode Load (Just (Id tacSymEntry)) Nothing Nothing) $ DS.toList $ llvOutLiveVariables liveVariablesInOut
+                in storeTacs ++ [tac] ++ loadTacs
 
         -- after generating code for labels, we need to load the used-arguments to their registers.
         -- if a var is not in the variableRegisterMap then it is not used in the program i.e. we can

--- a/src/FireLink/BackEnd/RegisterAllocationProcess.hs
+++ b/src/FireLink/BackEnd/RegisterAllocationProcess.hs
@@ -1,0 +1,21 @@
+{-|
+Module      : FireLink.BackEnd.RegisterAllocationProcess
+Description : Register allocation algorithm by graph coloration
+Stability   : experimental
+
+Attempts to allocate registers by doing chaitan algorithm as described here:
+https://cs.gmu.edu/~white/CS640/p98-chaitin.pdf
+
+[@initialStep@] process all codeblocks as we have infinite registers. Also, on function calls,
+all live variables at that moment are going to be "stored" before them. That is done to
+avoid that the interference graph will have edges between their own variables.
+-}
+module FireLink.BackEnd.RegisterAllocationProcess where
+
+import qualified Data.Map                       as DM
+import           FireLink.BackEnd.CodeGenerator (TACSymEntry (..))
+
+-- Semantic aliases
+type Register = Int
+type Color = Register
+type SymEntryRegisterMap = DM.Map TACSymEntry Color

--- a/src/FireLink/BackEnd/RegisterAllocationProcess.hs
+++ b/src/FireLink/BackEnd/RegisterAllocationProcess.hs
@@ -203,7 +203,7 @@ pushVertex reg = do
 
 
 graphBounds :: G.Graph -> G.Bounds
-graphBounds graph = (0, length $ G.vertices graph)
+graphBounds graph = (0, length (G.vertices graph) - 1)
 
 deleteVertex :: G.Vertex -> ColorState ()
 deleteVertex vertex = do

--- a/src/FireLink/BackEnd/RegisterAllocationProcess.hs
+++ b/src/FireLink/BackEnd/RegisterAllocationProcess.hs
@@ -12,9 +12,12 @@ avoid that the interference graph will have edges between their own variables.
 -}
 module FireLink.BackEnd.RegisterAllocationProcess (initialStep, SymEntryRegisterMap, Register) where
 
+import qualified Control.Monad.State                 as State
+import qualified Data.Array                          as A
 import           Data.Char                           (isDigit)
-import qualified Data.Map                            as DM
-import qualified Data.Set                            as DS
+import qualified Data.Graph                          as G
+import qualified Data.Map                            as Map
+import qualified Data.Set                            as Set
 import           Debug.Trace                         (trace)
 import           FireLink.BackEnd.CodeGenerator      (TAC (..),
                                                       TACSymEntry (..))
@@ -23,6 +26,7 @@ import           FireLink.BackEnd.FlowGraphGenerator (BasicBlock,
                                                       NumberedBlock,
                                                       getProgramVariables)
 import           FireLink.BackEnd.LivenessAnalyser
+import           FireLink.BackEnd.Utils
 import           FireLink.FrontEnd.SymTable          (Dictionary (..),
                                                       findArgsByFunName,
                                                       getOffset)
@@ -32,7 +36,9 @@ import           TACType
 -- Semantic aliases
 type Register = Int
 type Color = Register
-type SymEntryRegisterMap = DM.Map TACSymEntry Color
+
+-- | Associate a variable with a color (register). If the variable isn't in the
+type SymEntryRegisterMap = Map.Map TACSymEntry Color
 
 -- | Generate attempting final TAC assumming that we will have infinite registers i.e one register per actual variable
 -- | Also, before and after functions call live variables at that point will be saved to and loaded from memory respectively.
@@ -42,16 +48,16 @@ initialStep :: FlowGraph -> Dictionary -> (SymEntryRegisterMap, FlowGraph)
 initialStep flowGraph@(numberedBlocks, graph) dict =
     (variableRegisterMap, (preProcessCode, graph))
     where
-        programVariables :: DS.Set TACSymEntry
+        programVariables :: Set.Set TACSymEntry
         programVariables = getProgramVariables numberedBlocks
 
         -- | one for each actual variable
         initialRegisters :: [Register]
-        initialRegisters = [0 .. DS.size programVariables - 1]
+        initialRegisters = [0 .. Set.size programVariables - 1]
 
         -- | Map for each tac to its initial register
         variableRegisterMap :: SymEntryRegisterMap
-        variableRegisterMap = DM.fromList $ zip (DS.toList programVariables) initialRegisters
+        variableRegisterMap = Map.fromList $ zip (Set.toList programVariables) initialRegisters
 
         initialLivenessAnalysis :: [LineLiveVariables]
         initialLivenessAnalysis = livenessAnalyser flowGraph
@@ -86,13 +92,13 @@ initialStep flowGraph@(numberedBlocks, graph) dict =
             let liveVariablesInOut = getLivenessIn programPoint
                 storeTacs = map (\tacSymEntry ->
                     ThreeAddressCode Store (Just (Id tacSymEntry)) Nothing Nothing) $
-                        DS.toList $ llvInLiveVariables liveVariablesInOut
+                        Set.toList $ llvInLiveVariables liveVariablesInOut
                 toDeleteAfterCall = case maybeVar of
-                                        Nothing     -> DS.empty
-                                        Just (Id v) -> DS.singleton v
+                                        Nothing     -> Set.empty
+                                        Just (Id v) -> Set.singleton v
                 loadTacs = map (\tacSymEntry ->
                     ThreeAddressCode Load (Just (Id tacSymEntry)) Nothing Nothing) $
-                        DS.toList $ llvOutLiveVariables liveVariablesInOut DS.\\ toDeleteAfterCall
+                        Set.toList $ llvOutLiveVariables liveVariablesInOut Set.\\ toDeleteAfterCall
                 in storeTacs ++ [tac] ++ loadTacs
 
         -- after generating code for labels, we need to load the used-arguments to their registers.
@@ -102,10 +108,125 @@ initialStep flowGraph@(numberedBlocks, graph) dict =
             if isTacLabelFun tac then
                 let args = getFunctionArguments funName
                     loadTacsSet = map (\tacSymEntry ->
-                        case variableRegisterMap DM.!? tacSymEntry of
+                        case variableRegisterMap Map.!? tacSymEntry of
                             Nothing -> []
                             Just _ -> [ThreeAddressCode Load (Just (Id tacSymEntry)) Nothing Nothing]) args
                     loadTacs = concat loadTacsSet in
                         tac : loadTacs
             else [tac]
         go' (_, tac) = [tac]
+
+
+-- | Coloration state for the ColorState
+data ColorationState = ColorationState
+    { csGraph :: !G.Graph -- ^ state graph
+    , csDeletedVertices :: !(Set.Set G.Vertex) -- ^ Set of deleted vertices
+    , csRegisterStack :: ![G.Vertex] -- ^ register stack
+    }
+
+-- | Data.Graph graph representation is made by a range of integers describeing the set of vertices
+-- | So we can't exactly delete a single vertex, only remove all edges where it appears.
+-- | Even Data.Graph.outdegree will say that its outdegree is 0, so we need to have a set of deleted vertices
+-- | as well.
+type ColorState = State.State ColorationState
+
+-- | Helper to get the graph in a ColorState execution
+getGraph :: ColorState G.Graph
+getGraph = csGraph <$> State.get
+
+putGraph :: G.Graph -> ColorState ()
+putGraph graph = do
+    c <- State.get
+    State.put c{csGraph = graph}
+
+-- | Helper to get deleted vertices set in a ColorState execution
+getDeletedVertices :: ColorState (Set.Set G.Vertex)
+getDeletedVertices = csDeletedVertices <$> State.get
+
+putDeletedVertices :: Set.Set G.Vertex -> ColorState ()
+putDeletedVertices vertices = do
+    c <- State.get
+    State.put c{csDeletedVertices = vertices}
+
+-- | Helper to get current stack
+getRegisterStack :: ColorState [G.Vertex]
+getRegisterStack = csRegisterStack <$> State.get
+
+-- | Helper to put register stack
+putRegisterStack :: [G.Vertex] -> ColorState ()
+putRegisterStack stack = do
+    c <- State.get
+    State.put c{csRegisterStack = stack}
+
+-- | Push a register on top of the state's stack
+pushRegister :: Register -> ColorState ()
+pushRegister reg = do
+    stack <- getRegisterStack
+    putRegisterStack $ reg : stack
+
+
+graphBounds :: G.Graph -> G.Bounds
+graphBounds graph = (0, length $ G.vertices graph)
+
+deleteVertex :: G.Vertex -> ColorState ()
+deleteVertex vertex = do
+    graph <- getGraph
+    deletedVertices <- getDeletedVertices
+    let newEdges = filter (\(a, b) -> a /= vertex && b /= vertex) $ G.edges graph
+
+    putGraph $ G.buildG (graphBounds graph) newEdges
+    putDeletedVertices $ vertex `Set.insert` deletedVertices
+
+-- | Attempts to color a graph using
+attemptToColor :: InterferenceGraph -> ColorationState
+attemptToColor (varToVertexMap, interferenceGraph) =
+    State.execState go initialState
+
+    where
+        numberOfVertices :: Int
+        numberOfVertices = length $ G.vertices interferenceGraph
+
+        initialState :: ColorationState
+        initialState = ColorationState {
+            csGraph = interferenceGraph,
+            csDeletedVertices = Set.empty,
+            csRegisterStack = []
+        }
+        numberOfColors :: Int
+        numberOfColors = length availableRegisters
+
+        -- Attempt to choose a vertex
+        chooseVertexWithLessthanK :: ColorState (Maybe G.Vertex)
+        chooseVertexWithLessthanK = do
+            graph <- getGraph
+            deletedVertices <- getDeletedVertices
+            let vertices = G.vertices graph
+            let graphOutDegreePerVertex = A.assocs $ G.outdegree graph
+            -- We can choose a vertex which outdegree is between 0 and "numberOfColors", inclusive and exclusive.
+            -- Also, since Data.Graph doesn't provide the deletion of vertices, we need to keep a set of _deleted_
+            -- vertices
+            case filter (\(vertex, outdegree) ->
+                    0 <= outdegree && outdegree < numberOfColors &&
+                    vertex `Set.notMember` deletedVertices) graphOutDegreePerVertex of
+                []         -> return Nothing
+                (a, _) : _ -> return $ Just a
+
+
+        -- Returns a stack of vertices that emulated the reverse order of vertices that were delete
+        go :: ColorState ()
+        go = do
+            deletedVertices <- getDeletedVertices
+            -- | If every vertex was deleted, then coloration is finished
+            if Set.size deletedVertices == numberOfVertices then
+                return ()
+            -- | Otherwise, let's keep coloration
+            else do
+                maybeChoosenVertex <- chooseVertexWithLessthanK
+                case maybeChoosenVertex of
+                    -- | Nice! we can retrieve this vertex and add it to the stack
+                    Just v -> do
+                        deleteVertex v
+                        pushRegister v
+                        go
+                    -- | TODO: handle case when we can't get a vertex with less than k neighbours
+                    Nothing -> undefined

--- a/src/FireLink/BackEnd/RegisterAllocationProcess.hs
+++ b/src/FireLink/BackEnd/RegisterAllocationProcess.hs
@@ -15,7 +15,7 @@ Register allocation is made using optimistic colouring algorithm from Chaitan/Br
 Data.Graph.Graph represents directed graphs, but we actually need undirected. So, we need
 to remember that the existence of edge (i, j) implies that (j, i) exists (when i /= j)
 -}
-module FireLink.BackEnd.RegisterAllocationProcess (run, SymEntryRegisterMap, Register) where
+module FireLink.BackEnd.RegisterAllocationProcess (run, SymEntryRegisterMap, Register(..)) where
 
 import qualified Control.Monad.State                 as State
 import qualified Data.Array                          as A
@@ -40,7 +40,10 @@ import           TACType
 
 -- | To avoid confusions between G.Vertex and registers
 newtype Register = Register Int
-    deriving (Eq, Ord, Show)
+    deriving (Eq, Ord)
+
+instance Show Register where
+    show (Register r) = "$" ++ show r
 
 type Color = Register
 

--- a/src/FireLink/BackEnd/RegisterAllocationProcess.hs
+++ b/src/FireLink/BackEnd/RegisterAllocationProcess.hs
@@ -295,6 +295,10 @@ initialStep flowGraph@(numberedBlocks, graph) dict = (preProcessCode, graph)
 
 
 -- | Do liveness analysis on a program to construct the interference graph.
+-- state properties used:
+-- * csProgramFlowGraph, read
+-- * csInterferenceGraph, write
+-- * csLivenessInformation, write
 build :: ColorState ()
 build = do
     flowGraph <- getProgramFlowGraph
@@ -307,7 +311,11 @@ build = do
 -- | - number of definitions + number of usages
 -- | - TODO: try to implement cycle costs formula
 -- |
--- | The final cost for each variable is the sum of all of this heuristics
+-- | The final cost for each variable is the sum of all of this heuristics.
+-- state properties used:
+-- * csProgramVariables, read
+-- * csProgramFlowGraph, read
+-- * csSpillsCostMap, write
 costs :: ColorState ()
 costs = do
     programVars <- getProgramVariables'
@@ -337,6 +345,13 @@ costs = do
             associateSpillCost var sumOfCosts
 
 -- | Attempts to color a graph with the number of general-purpose registers
+-- state properties used:
+-- * csInterferenceGraph, read
+-- * csGraph, write
+-- * csDeletedVertices, write
+-- * csRegisterStack, write
+-- * csSpilledVertices, write
+-- * csSpillsCostMap, read
 simplify :: ColorState ()
 simplify = prepareState >> go
     where
@@ -413,6 +428,12 @@ simplify = prepareState >> go
 
 -- | Based on the stack, the actual interference graph and knowing that **no** register was spilled, we
 -- | finally attempt to color registers
+-- state properties used:
+-- * csVertexStack, read
+-- * csProgramFlowGraph, read
+-- * csInterferenceGraph, read
+-- * csColoredVertices, write
+-- * csGraph, write
 select :: ColorState (RegisterAssignment, FlowGraph)
 select = do
     colorationStack <- getVertexStack

--- a/src/FireLink/BackEnd/Utils.hs
+++ b/src/FireLink/BackEnd/Utils.hs
@@ -10,3 +10,8 @@ fixedPoint = until =<< ((==) =<<)
 -- | in the original order
 numberList :: [a] -> [(Int, a)]
 numberList = zip [0..]
+
+
+-- | List of available registers for MIPS32
+availableRegisters :: [Int]
+availableRegisters = [4 .. 25]

--- a/src/FireLink/BackEnd/Utils.hs
+++ b/src/FireLink/BackEnd/Utils.hs
@@ -1,0 +1,12 @@
+module FireLink.BackEnd.Utils where
+
+-- | Polimorfic implementation for fixedPoint algorithms
+fixedPoint :: Eq a => (a -> a) -> a -> a
+fixedPoint = until =<< ((==) =<<)
+
+-- | Given a list, returns a list of pairs in which
+-- | each first component is an unique integer, and each second
+-- | component is a (now uniquely identified) element of the first list,
+-- | in the original order
+numberList :: [a] -> [(Int, a)]
+numberList = zip [0..]

--- a/src/FireLink/BackEnd/Utils.hs
+++ b/src/FireLink/BackEnd/Utils.hs
@@ -1,5 +1,7 @@
 module FireLink.BackEnd.Utils where
 
+import           Data.Set as Set
+
 -- | Polimorfic implementation for fixedPoint algorithms
 fixedPoint :: Eq a => (a -> a) -> a -> a
 fixedPoint = until =<< ((==) =<<)
@@ -13,5 +15,5 @@ numberList = zip [0..]
 
 
 -- | List of available registers for MIPS32
-availableRegisters :: [Int]
-availableRegisters = [4 .. 25]
+availableRegisters :: Set.Set Int
+availableRegisters = Set.fromList [4 .. 25]

--- a/src/FireLink/FrontEnd/SymTable.hs
+++ b/src/FireLink/FrontEnd/SymTable.hs
@@ -7,6 +7,7 @@ import qualified FireLink.FrontEnd.Grammar      as G
 import qualified FireLink.FrontEnd.Tokens       as T
 import qualified FireLink.FrontEnd.TypeChecking as TC
 
+import           Data.Maybe                     (mapMaybe)
 import           Data.Sort                      (sortBy)
 
 type Scope = Int
@@ -202,6 +203,12 @@ findSymEntry idScope idName = head . filter (\s -> scope s == idScope) . findCha
 
 findSymEntryByName :: String -> Dictionary -> DictionaryEntry
 findSymEntryByName idName = head . findChain idName
+
+findArgsByFunName :: String -> Dictionary -> [DictionaryEntry]
+findArgsByFunName funName dict =
+    let funEntry = findSymEntryByName funName dict
+        [Fields Callable fieldScope] = mapMaybe findFieldsExtra (extra funEntry)
+        in findAllInScope fieldScope dict
 
 findAllFunctionsAndProcedures :: Dictionary -> DictionaryEntries
 findAllFunctionsAndProcedures = filter isFunction . concat . Map.elems


### PR DESCRIPTION
Global register allocation by graph coloring using Chaitan/Briggs algorithm:

Useful resources:
* http://lambda.uta.edu/cse5317/spring03/notes/node42.html
* http://web.cecs.pdx.edu/~mperkows/temp/register-allocation.pdf
* http://lambda.uta.edu/cse5317/spring03/notes/node40.html
* clase4.pdf classroom slildes

The output of the register allocation algorithm is a tuple `(FlowGraph, RegisterAssignment)` that will aid in the final code generation.

Interesting files are:
* src/FireLink/BackEnd/LivenessAnalyser.hs
* src/FireLink/BackEnd/RegisterAllocationProcess.hs