### PR TITLE
Fix soapstone name

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -665,7 +665,7 @@ La llamada a la función NO evalúa a ninguna expresión.
 Para imprimir una expresión a la salida estándar, se puede usar el siguiente procedimiento:
 
 ```firelink
-with orange saponite say <expresión>
+with orange soapstone say <expresión>
 ```
 
 Únicamente se pueden imprimir expresiones de los siguientes tipos:
@@ -751,8 +751,8 @@ Por ejemplo:
 ```firelink
 upgrading i with 1 soul until level 20
   traveling somewhere
-    with orange saponite say i \
-    with orange saponite say |\n|
+    with orange soapstone say i \
+    with orange soapstone say |\n|
   you died
 max level reached
 ```
@@ -786,8 +786,8 @@ Por ejemplo:
 ```firelink
 repairing i with titanite from biglist
   traveling somewhere
-    with orange saponite say i \
-    with orange saponite say |\n|
+    with orange soapstone say i \
+    with orange soapstone say |\n|
   you died
 weaponry repaired
 ```

--- a/samples/correct/bubblesort.souls
+++ b/samples/correct/bubblesort.souls
@@ -6,14 +6,14 @@ with
   var i of type humanity <<= 0,
   var a of type <1000>-chest of type humanity
 in your inventory
-  with orange saponite say @Enter a number: @ \
+  with orange soapstone say @Enter a number: @ \
   transpose into n \
 
   upgrading i with 1 soul until level n
     traveling somewhere
-      with orange saponite say @Enter element @ \
-      with orange saponite say n \
-      with orange saponite say @: @ \
+      with orange soapstone say @Enter element @ \
+      with orange soapstone say n \
+      with orange soapstone say @: @ \
       transpose into a<$i$>
     you died
   max level reached \
@@ -36,12 +36,12 @@ in your inventory
     you died
   max level reached \
 
-  with orange saponite say @Printing sorted array\n@ \
+  with orange soapstone say @Printing sorted array\n@ \
 
   upgrading i with 1 soul until level n
     traveling somewhere
-      with orange saponite say a<$i$> \
-      with orange saponite say @\n@ \
+      with orange soapstone say a<$i$> \
+      with orange soapstone say @\n@ \
       transpose into a<$i$>
     you died
   max level reached

--- a/samples/correct/dfs.souls
+++ b/samples/correct/dfs.souls
@@ -57,7 +57,7 @@ to the estus flask
     var i of type humanity <<= 0
   in your inventory
 
-    with orange saponite say n \
+    with orange soapstone say n \
 
     upgrading i with 1 soul until level g~>e
       traveling somewhere

--- a/samples/correct/empty_lists.souls
+++ b/samples/correct/empty_lists.souls
@@ -4,11 +4,11 @@ hello ashen one
     trust your inventory
       (<$ $> eq <$ <$ $> $>):
         traveling somewhere
-          with orange saponite say @They're equal!\n@
+          with orange soapstone say @They're equal!\n@
         you died
       liar!:
         traveling somewhere
-          with orange saponite say @They're not equal!\n@
+          with orange soapstone say @They're not equal!\n@
         you died
     inventory closed
   you died

--- a/samples/correct/even_odd.souls
+++ b/samples/correct/even_odd.souls
@@ -49,10 +49,10 @@ with
     var n of type humanity,
     var b of type bonfire
 in your inventory
-    -- with orange saponite say @Enter n: @ \
+    -- with orange soapstone say @Enter n: @ \
     transpose into n \
     b <<= summon even granting n to the knight \
-    with orange saponite say b
+    with orange soapstone say b
 you died
 
 farewell ashen one

--- a/samples/correct/factorial.souls
+++ b/samples/correct/factorial.souls
@@ -17,7 +17,7 @@ hello ashen one
       you died
     max level reached \
 
-    with orange saponite say r
+    with orange soapstone say r
   you died
 
 farewell ashen one

--- a/samples/correct/factorial_fun_iter.souls
+++ b/samples/correct/factorial_fun_iter.souls
@@ -22,10 +22,10 @@ traveling somewhere
 with
     var n of type humanity
 in your inventory
-    -- with orange saponite say @Enter n: @ \
+    -- with orange soapstone say @Enter n: @ \
     transpose into n \
     n <<= summon fact granting n to the knight \
-    with orange saponite say n
+    with orange soapstone say n
 you died
 
 farewell ashen one

--- a/samples/correct/factorial_fun_rec.souls
+++ b/samples/correct/factorial_fun_rec.souls
@@ -22,10 +22,10 @@ traveling somewhere
 with
     var n of type humanity
 in your inventory
-    -- with orange saponite say @Enter n: @ \
+    -- with orange soapstone say @Enter n: @ \
     transpose into n \
     n <<= summon fact granting n to the knight \
-    with orange saponite say n
+    with orange soapstone say n
 you died
 
 farewell ashen one

--- a/samples/correct/fibonacci_func.souls
+++ b/samples/correct/fibonacci_func.souls
@@ -30,7 +30,7 @@ in your inventory
   transpose into n \
   f <<= summon fibonacci
     granting n to the knight \
-  with orange saponite say f
+  with orange soapstone say f
 you died
 
 farewell ashen one

--- a/samples/correct/find_roots_polym_degree_two.souls
+++ b/samples/correct/find_roots_polym_degree_two.souls
@@ -78,7 +78,7 @@ hello ashen one
         you died
       (b*b - 4*a*c) lt 0:
         traveling somewhere
-          -- with orange saponite say @ERROR! This is a complex polynomial\n@ \
+          -- with orange soapstone say @ERROR! This is a complex polynomial\n@ \
           found <<= unlit
         you died
     inventory closed \
@@ -86,11 +86,11 @@ hello ashen one
     trust your inventory
       found:
         traveling somewhere
-          -- with orange saponite say @x1: @ \
-          with orange saponite say x1 \
-          -- with orange saponite say @\n@ >-< @x2: @ \
-          with orange saponite say x2 -- \
-          --with orange saponite say @\n@
+          -- with orange soapstone say @x1: @ \
+          with orange soapstone say x1 \
+          -- with orange soapstone say @\n@ >-< @x2: @ \
+          with orange soapstone say x2 -- \
+          --with orange soapstone say @\n@
         you died
     inventory closed
   you died

--- a/samples/correct/fizzbuzz.souls
+++ b/samples/correct/fizzbuzz.souls
@@ -12,21 +12,21 @@ hello ashen one
         trust your inventory
         i % 15 eq 0:
           traveling somewhere
-            -- with orange saponite say @FizzBuzz@ \
-            -- with orange saponite say @\n@
-               with orange saponite say 3 -- fizzbuzz
+            -- with orange soapstone say @FizzBuzz@ \
+            -- with orange soapstone say @\n@
+               with orange soapstone say 3 -- fizzbuzz
           you died
         i % 3 eq 0:
           traveling somewhere
-            -- with orange saponite say @Fizz@ \
-            --with orange saponite say @\n@
-              with orange saponite say 1 -- fizz
+            -- with orange soapstone say @Fizz@ \
+            --with orange soapstone say @\n@
+              with orange soapstone say 1 -- fizz
           you died
         i % 5 eq 0:
           traveling somewhere
-            --with orange saponite say @Buzz@ \
-            --with orange saponite say @\n@
-             with orange saponite say 2 -- buzz
+            --with orange soapstone say @Buzz@ \
+            --with orange soapstone say @\n@
+             with orange soapstone say 2 -- buzz
           you died
         inventory closed
       you died

--- a/samples/correct/full_color.souls
+++ b/samples/correct/full_color.souls
@@ -33,8 +33,8 @@ requesting
   ref n of type <123>-miracle
 to the estus flask
   traveling somewhere
-    with orange saponite say @hello world@ \
-    with orange saponite say n
+    with orange soapstone say @hello world@ \
+    with orange soapstone say n
   you died
 ashen estus flask consumed
 
@@ -68,7 +68,7 @@ in your inventory
   transpose into n \
   f <<= summon fibonacci
     granting n to the knight \
-  with orange saponite say f \
+  with orange soapstone say f \
 
   trust your inventory
     lit:
@@ -87,8 +87,8 @@ in your inventory
       you died
     liar!:
       traveling somewhere
-        with orange saponite say 1 lte n \
-        with orange saponite say 1 gt n
+        with orange soapstone say 1 lte n \
+        with orange soapstone say 1 gt n
       you died
   inventory closed \
 
@@ -96,14 +96,14 @@ in your inventory
     123:
       traveling somewhere
         n <<= - n \
-        with orange saponite say 1 lt n
+        with orange soapstone say 1 lt n
       you died
     empty dungeon:
       traveling somewhere
-        with orange saponite say 1 gte n \
-        with orange saponite say 1 eq n \
-        with orange saponite say 1 neq n \
-        with orange saponite say lit
+        with orange soapstone say 1 gte n \
+        with orange soapstone say 1 eq n \
+        with orange soapstone say 1 neq n \
+        with orange soapstone say lit
       you died
   dungeon exited \
 
@@ -115,7 +115,7 @@ in your inventory
 
   repairing ii with titanite from ff
     traveling somewhere
-      with orange saponite say ii ~> prop
+      with orange soapstone say ii ~> prop
     you died
   weaponry repaired \
 
@@ -125,12 +125,12 @@ in your inventory
       e ~> y ~> e <<= lit and not lit or unlit eq lit neq undiscovered
     you died
   covenant left \
-  with orange saponite say |!| \
-  with orange saponite say |\n| \
-  with orange saponite say |\|| \
-  with orange saponite say ascii_of |a| \
+  with orange soapstone say |!| \
+  with orange soapstone say |\n| \
+  with orange soapstone say |\|| \
+  with orange soapstone say ascii_of |a| \
   c <<= @hellow @ >-< @world@ \
-  with orange saponite say d<$n$> \
+  with orange soapstone say d<$n$> \
   n <<= size d \
   ff <<= {$ $} \
   ff <<= ff union ff \

--- a/samples/correct/guess_the_number.souls
+++ b/samples/correct/guess_the_number.souls
@@ -7,17 +7,17 @@ hello ashen one
   in your inventory
     while the r neq number covenant is active:
       traveling somewhere
-        with orange saponite say @Your guess: @ \
+        with orange soapstone say @Your guess: @ \
         transpose into r \
         trust your inventory
           r eq number:
             traveling somewhere
-              -- with orange saponite say @You got it!\n@ \
+              -- with orange soapstone say @You got it!\n@ \
               go back
             you died
           -- liar!:
             -- traveling somewhere
-              -- with orange saponite say @That's not it... Try again!\n@
+              -- with orange soapstone say @That's not it... Try again!\n@
             -- you died
         inventory closed
       you died

--- a/samples/correct/hello_stringy.souls
+++ b/samples/correct/hello_stringy.souls
@@ -8,7 +8,7 @@ hello ashen one
   with
     const h of type stringy <<= @Hello, world!@
   in your inventory
-    with orange saponite say h
+    with orange soapstone say h
   you died
 
 farewell ashen one

--- a/samples/correct/hello_world.souls
+++ b/samples/correct/hello_world.souls
@@ -1,7 +1,7 @@
 hello ashen one
 
   traveling somewhere
-    with orange saponite say @Hello, world!@
+    with orange soapstone say @Hello, world!@
   you died
 
 farewell ashen one

--- a/samples/correct/heron_sqrt.souls
+++ b/samples/correct/heron_sqrt.souls
@@ -29,21 +29,21 @@ traveling somewhere
 with
   var stop of type bonfire <<= unlit
 in your inventory
-  with orange saponite say @Square Root by Heron's Method\n@ \
+  with orange soapstone say @Square Root by Heron's Method\n@ \
 
   while the not stop covenant is active:
     traveling somewhere
     with
       var n of type hollow
     in your inventory
-      with orange saponite say @Enter the number: @ \
+      with orange soapstone say @Enter the number: @ \
       transpose into n \
 
       trust your inventory
         n lt 0:
           traveling somewhere
             stop <<= lit \
-            with orange saponite say @Only non-negative numbers are allowed!\n@
+            with orange soapstone say @Only non-negative numbers are allowed!\n@
           you died
         liar!:
           traveling somewhere
@@ -52,11 +52,11 @@ in your inventory
           in your inventory
             s <<= summon sqrt granting n, 1000000 to the knight \
 
-            with orange saponite say @Approximate square root: @ \
-            with orange saponite say s \
-            with orange saponite say @\n@ \
+            with orange soapstone say @Approximate square root: @ \
+            with orange soapstone say s \
+            with orange soapstone say @\n@ \
 
-            with orange saponite say @Wanna go again? (lit/unlit): @ \
+            with orange soapstone say @Wanna go again? (lit/unlit): @ \
             transpose into stop
           you died
       inventory closed

--- a/samples/correct/is_triangle.souls
+++ b/samples/correct/is_triangle.souls
@@ -31,15 +31,15 @@ hello ashen one
     var c of type hollow,
     var valid of type bonfire
   in your inventory
-    -- with orange saponite say @Enter the length of the first side:@ \
+    -- with orange soapstone say @Enter the length of the first side:@ \
     transpose into a \
-    -- with orange saponite say @Enter the length of the second side:@ \
+    -- with orange soapstone say @Enter the length of the second side:@ \
     transpose into b \
-    -- with orange saponite say @Enter the length of the third side:@ \
+    -- with orange soapstone say @Enter the length of the third side:@ \
     transpose into c \
     valid <<= summon is_valid_triangle
       granting a, b, c to the knight\
-    with orange saponite say valid
+    with orange soapstone say valid
   you died
 
 farewell ashen one

--- a/samples/correct/quicksort.souls
+++ b/samples/correct/quicksort.souls
@@ -30,7 +30,7 @@ to the estus flask
   in your inventory
     upgrading i with 1 soul until level n
       traveling somewhere
-        with orange saponite say @Enter value: @ \
+        with orange soapstone say @Enter value: @ \
         transpose into arr<$i$>
       you died
     max level reached \
@@ -49,7 +49,7 @@ to the estus flask
   in your inventory
     upgrading i with 1 soul until level n
       traveling somewhere
-        with orange saponite say @Enter value: @ \
+        with orange soapstone say @Enter value: @ \
         transpose into arr<$i$>
       you died
     max level reached \
@@ -68,7 +68,7 @@ to the estus flask
   in your inventory
     upgrading i with 1 soul until level n
       traveling somewhere
-        with orange saponite say @Enter value: @ \
+        with orange soapstone say @Enter value: @ \
         transpose into arr<$i$>
       you died
     max level reached \
@@ -87,8 +87,8 @@ to the estus flask
   in your inventory
     upgrading i with 1 soul until level n
       traveling somewhere
-        with orange saponite say arr<$i$> \
-        with orange saponite say @\n@
+        with orange soapstone say arr<$i$> \
+        with orange soapstone say @\n@
       you died
     max level reached \
     go back
@@ -106,8 +106,8 @@ to the estus flask
   in your inventory
     upgrading i with 1 soul until level n
       traveling somewhere
-        with orange saponite say arr<$i$> \
-        with orange saponite say @\n@
+        with orange soapstone say arr<$i$> \
+        with orange soapstone say @\n@
       you died
     max level reached \
     go back
@@ -125,8 +125,8 @@ to the estus flask
   in your inventory
     upgrading i with 1 soul until level n
       traveling somewhere
-        with orange saponite say arr<$i$> \
-        with orange saponite say @\n@
+        with orange soapstone say arr<$i$> \
+        with orange soapstone say @\n@
       you died
     max level reached \
     go back
@@ -357,19 +357,19 @@ with
   var stop of type bonfire <<= unlit
 in your inventory
 
-  with orange saponite say @Quicksort <<in-place>>\n@ \
+  with orange soapstone say @Quicksort <<in-place>>\n@ \
 
   while the not stop covenant is active:
     traveling somewhere
       with var option of type sign
     in your inventory
-      with orange saponite say @Want to sort (i)ntegers, (c)haracters, (f)loats or (q)uit? (i/c/f/q): @ \
+      with orange soapstone say @Want to sort (i)ntegers, (c)haracters, (f)loats or (q)uit? (i/c/f/q): @ \
       transpose into option \
 
       trust your inventory
         option neq |i| and option neq |c| and option neq |f|:
           traveling somewhere
-            with orange saponite say @Exiting...\n@ \
+            with orange soapstone say @Exiting...\n@ \
             stop <<= lit
           you died
         liar!:
@@ -377,7 +377,7 @@ in your inventory
           with
             var n of type humanity
           in your inventory
-            with orange saponite say @Enter the size (between 1 and 100): @ \
+            with orange soapstone say @Enter the size (between 1 and 100): @ \
             transpose into n \
 
             trust your inventory
@@ -392,7 +392,7 @@ in your inventory
                       in your inventory
                         cast readarri offering n, arr to the estus flask \
                         cast quicksorti offering n, arr, 0, n - 1 to the estus flask \
-                        with orange saponite say @Printing result: \n@ \
+                        with orange soapstone say @Printing result: \n@ \
                         cast printarri offering n, arr to the estus flask
                       you died
                     option eq |c|:
@@ -402,7 +402,7 @@ in your inventory
                       in your inventory
                         cast readarrc offering n, arr to the estus flask \
                         cast quicksortc offering n, arr, 0, n - 1 to the estus flask \
-                        with orange saponite say @Printing result: \n@ \
+                        with orange soapstone say @Printing result: \n@ \
                         cast printarrc offering n, arr to the estus flask
                       you died
                     option eq |f|:
@@ -412,7 +412,7 @@ in your inventory
                       in your inventory
                         cast readarrf offering n, arr to the estus flask \
                         cast quicksortf offering n, arr, 0, n - 1 to the estus flask \
-                        with orange saponite say @Printing result: \n@ \
+                        with orange soapstone say @Printing result: \n@ \
                         cast printarrf offering n, arr to the estus flask
                       you died
                   inventory closed
@@ -420,7 +420,7 @@ in your inventory
                 you died
               liar!:
                 traveling somewhere
-                  with orange saponite say @Invalid amount, aborting...\n@ \
+                  with orange soapstone say @Invalid amount, aborting...\n@ \
                   stop <<= lit
                 you died
             inventory closed

--- a/samples/correct/sample1.souls
+++ b/samples/correct/sample1.souls
@@ -3,7 +3,7 @@ hello ashen one
 
 spell hello_world
   traveling somewhere
-    with orange saponite say @Hello, world!@
+    with orange soapstone say @Hello, world!@
   you died
 ashen estus flask consumed
 

--- a/samples/correct/stats.souls
+++ b/samples/correct/stats.souls
@@ -144,63 +144,63 @@ with
   var stop of type bonfire
 in your inventory
 
-  with orange saponite say @Welcome to the stats calculator!\n@ \
+  with orange soapstone say @Welcome to the stats calculator!\n@ \
 
   while the not stop covenant is active:
     traveling somewhere
     with
       var t of type humanity
     in your inventory
-      with orange saponite say @Iteration started\n@ \
-      with orange saponite say @Enter the amount of values to process: @ \
+      with orange soapstone say @Iteration started\n@ \
+      with orange soapstone say @Enter the amount of values to process: @ \
 
       transpose into t \
 
       trust your inventory
         t lte 0:
           traveling somewhere
-            with orange saponite say @At least 1 value is needed. Stopping the program.\n@ \
+            with orange soapstone say @At least 1 value is needed. Stopping the program.\n@ \
             stop <<= lit
           you died
         liar!:
           traveling somewhere
-            with orange saponite say @We will now process each value\n@ \
+            with orange soapstone say @We will now process each value\n@ \
 
             -- Each value is read
             i <<= 0 \
             upgrading i with 1 soul until level t
               traveling somewhere
-                with orange saponite say @Enter value: @ \
+                with orange soapstone say @Enter value: @ \
                 transpose into arr<$i$>
               you died
             max level reached \
 
             -- Printing stuff
-            with orange saponite say @Number of values: @ \
-            with orange saponite say t \
-            with orange saponite say @\n@ \
+            with orange soapstone say @Number of values: @ \
+            with orange soapstone say t \
+            with orange soapstone say @\n@ \
 
-            with orange saponite say @Min value: @ \
-            with orange saponite say summon min granting t, arr to the knight \
-            with orange saponite say @\n@ \
+            with orange soapstone say @Min value: @ \
+            with orange soapstone say summon min granting t, arr to the knight \
+            with orange soapstone say @\n@ \
 
-            with orange saponite say @Max value: @ \
-            with orange saponite say summon max granting t, arr to the knight \
-            with orange saponite say @\n@ \
+            with orange soapstone say @Max value: @ \
+            with orange soapstone say summon max granting t, arr to the knight \
+            with orange soapstone say @\n@ \
 
-            with orange saponite say @Average: @ \
-            with orange saponite say summon avg granting t, arr to the knight \
-            with orange saponite say @\n@ \
+            with orange soapstone say @Average: @ \
+            with orange soapstone say summon avg granting t, arr to the knight \
+            with orange soapstone say @\n@ \
 
-            with orange saponite say @Variance: @ \
-            with orange saponite say summon vari granting t, arr to the knight \
-            with orange saponite say @\n@ \
+            with orange soapstone say @Variance: @ \
+            with orange soapstone say summon vari granting t, arr to the knight \
+            with orange soapstone say @\n@ \
 
-            with orange saponite say @Standard Deviation: @ \
-            with orange saponite say summon std granting t, arr to the knight \
-            with orange saponite say @\n@ \
+            with orange soapstone say @Standard Deviation: @ \
+            with orange soapstone say summon std granting t, arr to the knight \
+            with orange soapstone say @\n@ \
 
-            with orange saponite say @Wanna go again? (lit/unlit): @ \
+            with orange soapstone say @Wanna go again? (lit/unlit): @ \
             transpose into stop
           you died
       inventory closed

--- a/samples/error_recovery/alias_list_end.souls
+++ b/samples/error_recovery/alias_list_end.souls
@@ -4,7 +4,7 @@ requiring help of
     knight onion humanity
 
 traveling somewhere
-    with orange saponite say @Hello, ashen one!@
+    with orange soapstone say @Hello, ashen one!@
 you died
 
 farewell ashen one

--- a/samples/error_recovery/closing_brace.souls
+++ b/samples/error_recovery/closing_brace.souls
@@ -7,7 +7,7 @@ requiring help of
 help received
 
 traveling somewhere
-    with orange saponite say @Hello, ashen one!@
+    with orange soapstone say @Hello, ashen one!@
 you died
 
 farewell ashen one

--- a/samples/error_recovery/declaration_list_end.souls
+++ b/samples/error_recovery/declaration_list_end.souls
@@ -3,7 +3,7 @@ hello ashen one
 traveling somewhere
 with
     var n of type humanity
-    with orange saponite say @Hello, ashen one!@
+    with orange soapstone say @Hello, ashen one!@
 you died
 
 farewell ashen one

--- a/samples/error_recovery/for_each_end.souls
+++ b/samples/error_recovery/for_each_end.souls
@@ -7,8 +7,8 @@ traveling somewhere
     in your inventory
     repairing i with titanite from biglist
         traveling somewhere
-            with orange saponite say i \
-            with orange saponite say |\n|
+            with orange soapstone say i \
+            with orange soapstone say |\n|
         you died
 
 you died

--- a/samples/error_recovery/for_end.souls
+++ b/samples/error_recovery/for_end.souls
@@ -6,8 +6,8 @@ traveling somewhere
     in your inventory
     upgrading i with 1 soul until level 20
         traveling somewhere
-            with orange saponite say i \
-            with orange saponite say |\n|
+            with orange soapstone say i \
+            with orange soapstone say |\n|
         you died
 
 you died

--- a/samples/error_recovery/instruction_list_end.souls
+++ b/samples/error_recovery/instruction_list_end.souls
@@ -1,6 +1,6 @@
 hello ashen one
 
 traveling somewhere
-    with orange saponite say @Hello, ashen one!@
+    with orange soapstone say @Hello, ashen one!@
 
 farewell ashen one

--- a/samples/error_recovery/program_end.souls
+++ b/samples/error_recovery/program_end.souls
@@ -1,5 +1,5 @@
 hello ashen one
 
 traveling somewhere
-    with orange saponite say @Hello, ashen one!@
+    with orange soapstone say @Hello, ashen one!@
 you died

--- a/samples/flawed/lexer_error.souls
+++ b/samples/flawed/lexer_error.souls
@@ -11,18 +11,18 @@ hello ashen one
       trust your inventory
       i % 15 eq 0:
         traveling somewhere
-          with orange saponite say @FizzBuzz@ \
-          with orange saponite say @\n@
+          with orange soapstone say @FizzBuzz@ \
+          with orange soapstone say @\n@
         you died
       i % 3 eq 0:
         traveling somewhere
-          with orange saponite say @Fizz@ \
-      ¿    with orange saponite say @\n@
+          with orange soapstone say @Fizz@ \
+      ¿    with orange soapstone say @\n@
         you died
       i % 5 eq 0:
         traveling somewhere
-          with orange saponite say @Buzz@ \
-          with orange saponite say @\n@
+          with orange soapstone say @Buzz@ \
+          with orange soapstone say @\n@
         you died
       inventory closed
 

--- a/samples/flawed/parser_error.souls
+++ b/samples/flawed/parser_error.souls
@@ -1,7 +1,7 @@
 hello ashen one
 
   traveling somewhere \
-    with orange saponite say @Hello, world!@ \
+    with orange soapstone say @Hello, world!@ \
   you died
 @Goodbye!~@
 farewell ashen one

--- a/samples/flawed/test.souls
+++ b/samples/flawed/test.souls
@@ -44,21 +44,21 @@ with
     }
     -- var myAlias of type myAlias
 in your inventory
-    with orange saponite say patata \ -- patataArray<$ |a| $>
-    with orange saponite say summon myIntFun granting
+    with orange soapstone say patata \ -- patataArray<$ |a| $>
+    with orange soapstone say summon myIntFun granting
         ascii_of throw a patataPointer, |a| to the knight \
-    with orange saponite say (throw a patataPointer) lt |a| \
-    with orange saponite say ascii_of patataCuento \
-    with orange saponite say patataArray >-< x1 \
-    with orange saponite say mySet intersect patata \
-    with orange saponite say (throw a (x1<$ 0 $> ~> x2 ~> x3)) + patata \
+    with orange soapstone say (throw a patataPointer) lt |a| \
+    with orange soapstone say ascii_of patataCuento \
+    with orange soapstone say patataArray >-< x1 \
+    with orange soapstone say mySet intersect patata \
+    with orange soapstone say (throw a (x1<$ 0 $> ~> x2 ~> x3)) + patata \
     trust your inventory
     lit:
         traveling somewhere
         with
             var myAlias of type myAlias
         in your inventory
-            with orange saponite say myAlias
+            with orange soapstone say myAlias
         you died
     inventory closed
 you died

--- a/samples/tac_generation/arrays/arrays8.souls
+++ b/samples/tac_generation/arrays/arrays8.souls
@@ -14,7 +14,7 @@ traveling somewhere
 with
     var x of type <10>-chest of type <123>-chest of type bonfire
 in your inventory
-    with orange saponite say size x<$0$>
+    with orange soapstone say size x<$0$>
 you died
 
 farewell ashen one

--- a/samples/tac_generation/foreach/foreach1.souls
+++ b/samples/tac_generation/foreach/foreach1.souls
@@ -7,7 +7,7 @@ in your inventory
 
     repairing i with titanite from a
         traveling somewhere
-            with orange saponite say i
+            with orange soapstone say i
         you died
     weaponry repaired
 you died

--- a/samples/tac_generation/io1.souls
+++ b/samples/tac_generation/io1.souls
@@ -11,10 +11,10 @@ in your inventory
     transpose into b \
     transpose into c \
     d <<= lit \
-    with orange saponite say a \
-    with orange saponite say c \
-    with orange saponite say b \
-    with orange saponite say d
+    with orange soapstone say a \
+    with orange soapstone say c \
+    with orange soapstone say b \
+    with orange soapstone say d
 you died
 
 farewell ashen one

--- a/samples/type_checking/container_with_casting.souls
+++ b/samples/type_checking/container_with_casting.souls
@@ -4,7 +4,7 @@ traveling somewhere
 with
     var x of type armor of type armor of type humanity <<= {${$1, 2, 3.0$}$}
 in your inventory
-    with orange saponite say x
+    with orange soapstone say x
 you died
 
 farewell ashen one

--- a/samples/type_checking/container_without_casting.souls
+++ b/samples/type_checking/container_without_casting.souls
@@ -4,7 +4,7 @@ traveling somewhere
 with
     var x of type armor of type big humanity <<= {$1, 2$}
 in your inventory
-    with orange saponite say x
+    with orange soapstone say x
 you died
 
 farewell ashen one

--- a/samples/type_checking/error_propagation.souls
+++ b/samples/type_checking/error_propagation.souls
@@ -2,9 +2,9 @@ hello ashen one
 
 traveling somewhere
     -- this should only report one error
-    with orange saponite say 1 + (1 + |a|) \
-    with orange saponite say 1 + (summon f) \
-    with orange saponite say fff
+    with orange soapstone say 1 + (1 + |a|) \
+    with orange soapstone say 1 + (summon f) \
+    with orange soapstone say fff
 you died
 
 farewell ashen one

--- a/samples/type_checking/io_operations.souls
+++ b/samples/type_checking/io_operations.souls
@@ -11,21 +11,21 @@ with
     var g of type link { y of type humanity }
 in your inventory
     -- Valid
-    with orange saponite say a \
+    with orange soapstone say a \
     transpose into a \
-    with orange saponite say d \
+    with orange soapstone say d \
     transpose into d \
-    with orange saponite say e \
+    with orange soapstone say e \
     transpose into e \
-    with orange saponite say f \
+    with orange soapstone say f \
     transpose into f \
 
     -- Invalid
-    with orange saponite say b \
+    with orange soapstone say b \
     transpose into b \
-    with orange saponite say c \
+    with orange soapstone say c \
     transpose into c \
-    with orange saponite say g \
+    with orange soapstone say g \
     transpose into g
 you died
 

--- a/samples/type_checking/type_errors.souls
+++ b/samples/type_checking/type_errors.souls
@@ -1,8 +1,8 @@
 hello ashen one
 
 traveling somewhere
-    with orange saponite say 1 + |a| \
-    with orange saponite say 1 lte |a|
+    with orange soapstone say 1 + |a| \
+    with orange soapstone say 1 lte |a|
 you died
 
 farewell ashen one

--- a/samples/type_errors.souls
+++ b/samples/type_errors.souls
@@ -1,8 +1,8 @@
 hello ashen one
 
 traveling somewhere
-    with orange saponite say 1 + |a| \
-    with orange saponite say 1 lte |a|
+    with orange soapstone say 1 + |a| \
+    with orange soapstone say 1 lte |a|
 you died
 
 farewell ashen one

--- a/src/FireLink/FrontEnd/Lexer.x
+++ b/src/FireLink/FrontEnd/Lexer.x
@@ -29,7 +29,7 @@ tokens :-
     with                                  { makeToken TkWith }
     in\ your\ inventory                   { makeToken TkDeclarationEnd }
     transpose\ into                       { makeToken TkRead }
-    with\ orange\ saponite\ say           { makeToken TkPrint }
+    with\ orange\ soapstone\ say           { makeToken TkPrint }
 
     -- Functions and procedures
     spell                                 { makeToken TkSpell }

--- a/src/FireLink/FrontEnd/Tokens.hs
+++ b/src/FireLink/FrontEnd/Tokens.hs
@@ -66,7 +66,7 @@ data AbstractToken = TkId | TkConst | TkVar | TkOfType | TkAsig
     | TkSpellParsEnd
     | TkReturnWith
     -- Basic I/O
-    | TkPrint -- with orange saponite say
+    | TkPrint -- with orange soapstone say
     | TkRead -- transpose into
     -- Basic selection
     | TkIf -- trust your inventory

--- a/test/Lexer/ProgramStructureSpec.hs
+++ b/test/Lexer/ProgramStructureSpec.hs
@@ -48,8 +48,8 @@ spec = describe "Lexer" $ do
     let atok = getAbstractToken $ head toks
     atok `shouldBe` TkSeq
 
-  it "accepts `with orange saponite say` as a valid token" $ do
-    let x = "with orange saponite say"
+  it "accepts `with orange soapstone say` as a valid token" $ do
+    let x = "with orange soapstone say"
     let ([], toks) = scanTokens x
     let atok = getAbstractToken $ head toks
     atok `shouldBe` TkPrint

--- a/test/Parser/BoundedLoopStructuresSpec.hs
+++ b/test/Parser/BoundedLoopStructuresSpec.hs
@@ -20,14 +20,14 @@ spec = describe "Bounded loop structures" $ do
         runTestForInvalidProgram $ buildProgram "\
         \ upgrading |a| with 2 souls until level 123 \
         \   traveling somewhere \
-        \       with orange saponite say @hello@ \
+        \       with orange soapstone say @hello@ \
         \   you died \
         \ max level reached"
     it "accepts well formed bounded iterations" $
         runTestForValidProgram (buildProgram "\
         \ upgrading aa with 2 souls until level 123 \
         \   traveling somewhere \
-        \       with orange saponite say @hello@ \
+        \       with orange soapstone say @hello@ \
         \   you died \
         \ max level reached") (\(Program (CodeBlock [
             InstFor (Id Token {cleanedString="aa"} _) Expr{expAst=(IntLit 2)} Expr{expAst=(IntLit 123)} (CodeBlock _ _), InstReturn

--- a/test/Parser/ConditionalStructuresSpec.hs
+++ b/test/Parser/ConditionalStructuresSpec.hs
@@ -26,13 +26,13 @@ spec = do
             runTestForInvalidProgram $ buildProgram "\
             \ liar!: \
             \   traveling somewhere \
-            \       with orange saponite say @hello world@ \
+            \       with orange soapstone say @hello world@ \
             \   you died"
         it "accepts a selection block with only one if statment" $
             runTestForValidProgram (buildProgram "\
             \ lit: \
             \   traveling somewhere \
-            \       with orange saponite say @hello world@ \
+            \       with orange soapstone say @hello world@ \
             \ you died") (\(Program (CodeBlock [InstIf [
                 GuardedCase
                     Expr{expAst=TrueLit}
@@ -43,11 +43,11 @@ spec = do
             runTestForValidProgram (buildProgram "\
             \ lit: \
             \   traveling somewhere \
-            \       with orange saponite say @hello world@ \
+            \       with orange soapstone say @hello world@ \
             \   you died \
             \ unlit: \
             \   traveling somewhere \
-            \       with orange saponite say @goodbye@ \
+            \       with orange soapstone say @goodbye@ \
             \   you died") (\(Program (CodeBlock [InstIf [
                 GuardedCase
                     Expr{expAst=TrueLit}
@@ -59,11 +59,11 @@ spec = do
             runTestForValidProgram (buildProgram "\
             \ lit: \
             \   traveling somewhere \
-            \       with orange saponite say @hello world@ \
+            \       with orange soapstone say @hello world@ \
             \   you died \
             \ liar!: \
             \   traveling somewhere \
-            \       with orange saponite say @goodbye@ \
+            \       with orange soapstone say @goodbye@ \
             \   you died") (\(Program (CodeBlock [InstIf [
                 GuardedCase
                     Expr{expAst=TrueLit}
@@ -76,15 +76,15 @@ spec = do
             runTestForInvalidProgram $ buildProgram "\
             \ lit: \
             \   traveling somewhere \
-            \       with orange saponite say @hello world@ \
+            \       with orange soapstone say @hello world@ \
             \   you died \
             \ liar!: \
             \   traveling somewhere \
-            \       with orange saponite say @hello world@ \
+            \       with orange soapstone say @hello world@ \
             \   you died \
             \ liar!: \
             \   traveling somewhere \
-            \       with orange saponite say @hello world@ \
+            \       with orange soapstone say @hello world@ \
             \   you died"
     describe "Switch statements" $ do
         let buildProgram c = "\
@@ -104,13 +104,13 @@ spec = do
             runTestForInvalidProgram $ buildProgram "\
             \ empty dungeon: \
             \   traveling somewhere \
-            \       with orange saponite say @hello@ \
+            \       with orange soapstone say @hello@ \
             \   you died"
         it "accepts switch statament with only one case" $
             runTestForValidProgram (buildProgram "\
             \ 1: \
             \   traveling somewhere \
-            \       with orange saponite say @hello@ \
+            \       with orange soapstone say @hello@ \
             \   you died") (\(Program (CodeBlock [InstSwitch Expr{expAst=(IdExpr (Id Token {cleanedString="a"} _))} [
                     Case Expr{expAst=(IntLit 1)} (CodeBlock [InstPrint Expr{expAst=(StringLit "hello")}] _)
                 ], InstReturn] _)) -> True)
@@ -119,25 +119,25 @@ spec = do
             runTestForInvalidProgram $ buildProgram "\
             \ 1: \
             \   traveling somewhere \
-            \       with orange saponite say @hello@ \
+            \       with orange soapstone say @hello@ \
             \   you died \
             \ empty dungeon: \
             \   traveling somewhere \
-            \       with orange saponite say @hello@ \
+            \       with orange soapstone say @hello@ \
             \   you died \
             \ empty dungeon: \
             \   traveling somewhere \
-            \       with orange saponite say @hello@ \
+            \       with orange soapstone say @hello@ \
             \   you died "
         it "accepts swith statement with several non-default cases" $
             runTestForValidProgram (buildProgram "\
             \ 1: \
             \   traveling somewhere \
-            \       with orange saponite say @hello@ \
+            \       with orange soapstone say @hello@ \
             \   you died \
             \ 2: \
             \   traveling somewhere \
-            \       with orange saponite say @bye@ \
+            \       with orange soapstone say @bye@ \
             \   you died") (\(Program (CodeBlock [InstSwitch Expr{expAst=(IdExpr (Id Token {cleanedString="a"} _))} [
                     Case Expr{expAst=(IntLit 1)} (CodeBlock [InstPrint Expr{expAst=(StringLit "hello")}] _),
                     Case Expr{expAst=(IntLit 2)} (CodeBlock [InstPrint Expr{expAst=(StringLit "bye")}] _)
@@ -147,15 +147,15 @@ spec = do
             runTestForValidProgram (buildProgram "\
             \ 1: \
             \   traveling somewhere \
-            \       with orange saponite say @hello@ \
+            \       with orange soapstone say @hello@ \
             \   you died \
             \ 2: \
             \   traveling somewhere \
-            \       with orange saponite say @bye@ \
+            \       with orange soapstone say @bye@ \
             \   you died \
             \ empty dungeon: \
             \   traveling somewhere \
-            \       with orange saponite say @empty@ \
+            \       with orange soapstone say @empty@ \
             \   you died") (\(Program (CodeBlock [InstSwitch Expr{expAst=IdExpr (Id Token {cleanedString="a"} _)} [
                     Case Expr{expAst=(IntLit 1)} (CodeBlock [InstPrint Expr{expAst=StringLit "hello"}] _),
                     Case Expr{expAst=(IntLit 2)} (CodeBlock [InstPrint Expr{expAst=StringLit "bye"}] _),

--- a/test/Parser/ForEachLoopStructuresSpec.hs
+++ b/test/Parser/ForEachLoopStructuresSpec.hs
@@ -20,14 +20,14 @@ spec = describe "Loops over structures" $ do
         runTestForInvalidProgram $ buildProgram "\
         \ repairing 1 with titanite from b \
         \ traveling somewhere \
-        \   with orange saponite say @@ \
+        \   with orange soapstone say @@ \
         \ you died \
         \ weaponry repaired"
     it "accepts on well-formed loops" $
         runTestForValidProgram (buildProgram "\
         \ repairing a with titanite from b \
         \ traveling somewhere \
-        \   with orange saponite say @@ \
+        \   with orange soapstone say @@ \
         \ you died \
         \ weaponry repaired") (\(Program (
             CodeBlock [

--- a/test/Parser/InstructionsSpec.hs
+++ b/test/Parser/InstructionsSpec.hs
@@ -33,7 +33,7 @@ spec = describe "Instructions" $ do
         \   var patata of type humanity \
         \ in your inventory \
 
-        \   with orange saponite say @hello world@ \\ \
+        \   with orange soapstone say @hello world@ \\ \
         \   transpose into patata \
         \ you died \
 

--- a/test/Parser/UnboundedLoopStructuresSpec.hs
+++ b/test/Parser/UnboundedLoopStructuresSpec.hs
@@ -23,7 +23,7 @@ spec = describe "Unbounded looping" $ do
         runTestForValidProgram (buildProgram "\
         \ while the unlit covenant is active: \
             \ traveling somewhere \
-            \   with orange saponite say @@ \
+            \   with orange soapstone say @@ \
             \ you died \
         \ covenant left")  (\(Program (
             CodeBlock [

--- a/test/Semantic/FunctionsSpec.hs
+++ b/test/Semantic/FunctionsSpec.hs
@@ -272,7 +272,7 @@ spec = do
             \ traveling somewhere\n\
             \   with orange soapstone say summon fun2\n\
             \ you died \
-            \ farewell ashen one" `U.shouldErrorOn` ("fun2", 9, 36)
+            \ farewell ashen one" `U.shouldErrorOn` ("fun2", 9, 37)
         it "allows recursion" $
             U.shouldNotError "hello ashen one\n\
 

--- a/test/Semantic/FunctionsSpec.hs
+++ b/test/Semantic/FunctionsSpec.hs
@@ -29,7 +29,7 @@ spec = do
 
 
             \ traveling somewhere \
-            \ with orange saponite say @hello world@ \
+            \ with orange soapstone say @hello world@ \
             \ you died \
             \ farewell ashen one"
             (_, ST.SymTable {ST.stDict=dict}, _) <- U.extractSymTable p
@@ -51,7 +51,7 @@ spec = do
 
 
             \ traveling somewhere \
-            \ with orange saponite say @hello world@ \
+            \ with orange soapstone say @hello world@ \
             \ you died \
             \ farewell ashen one"
             (_, ST.SymTable {ST.stDict=dict}, _) <- U.extractSymTable p
@@ -76,7 +76,7 @@ spec = do
 
 
             \ traveling somewhere \
-            \ with orange saponite say @hello world@ \
+            \ with orange soapstone say @hello world@ \
             \ you died \
             \ farewell ashen one"
             (_, ST.SymTable {ST.stDict=dict}, _) <- U.extractSymTable p
@@ -100,7 +100,7 @@ spec = do
 
 
             \ traveling somewhere \
-            \ with orange saponite say @hello world@ \
+            \ with orange soapstone say @hello world@ \
             \ you died \
             \ farewell ashen one"
             (_, ST.SymTable {ST.stDict=dict}, _) <- U.extractSymTable p
@@ -129,7 +129,7 @@ spec = do
 
 
             \ traveling somewhere \
-            \ with orange saponite say @hello world@ \
+            \ with orange soapstone say @hello world@ \
             \ you died \
             \ farewell ashen one" `U.shouldErrorOn` ("x", 5, 8)
         it "rejects to declare variables on the first scope of a function whose names are on the arg list" $
@@ -151,7 +151,7 @@ spec = do
 
 
             \ traveling somewhere \
-            \ with orange saponite say @hello world@ \
+            \ with orange soapstone say @hello world@ \
             \ you died \
             \ farewell ashen one" `U.shouldErrorOn` ("x", 8, 8)
         it "rejects to declare variables on the second (2<=) scope of a function whose names are on the arg list" $
@@ -180,7 +180,7 @@ spec = do
 
 
             \ traveling somewhere \
-            \ with orange saponite say @hello world@ \
+            \ with orange soapstone say @hello world@ \
             \ you died \
             \ farewell ashen one" `U.shouldErrorOn` ("x", 10, 12)
         it "allows to declare more than 1 function" $ do
@@ -206,7 +206,7 @@ spec = do
 
 
             \ traveling somewhere \
-            \ with orange saponite say @hello world@ \
+            \ with orange soapstone say @hello world@ \
             \ you died \
             \ farewell ashen one"
             (_, ST.SymTable {ST.stDict=dict}, errors) <- U.extractSymTable p
@@ -236,7 +236,7 @@ spec = do
 
 
             \ traveling somewhere \
-            \ with orange saponite say summon fun \
+            \ with orange soapstone say summon fun \
             \ you died \
             \ farewell ashen one"
         it "allows to call declared functions with parameters" $
@@ -253,7 +253,7 @@ spec = do
 
 
             \ traveling somewhere\n\
-            \ with orange saponite say summon fun\n\
+            \ with orange soapstone say summon fun\n\
             \ you died \
             \ farewell ashen one"
         it "rejects to call non-declared functions" $
@@ -270,7 +270,7 @@ spec = do
 
 
             \ traveling somewhere\n\
-            \   with orange saponite say summon fun2\n\
+            \   with orange soapstone say summon fun2\n\
             \ you died \
             \ farewell ashen one" `U.shouldErrorOn` ("fun2", 9, 36)
         it "allows recursion" $
@@ -287,7 +287,7 @@ spec = do
 
 
             \ traveling somewhere\n\
-            \   with orange saponite say summon fun\n\
+            \   with orange soapstone say summon fun\n\
             \ you died \
             \ farewell ashen one"
         it "allows corecursion" $ do
@@ -313,7 +313,7 @@ spec = do
 
 
             \ traveling somewhere\n\
-            \   with orange saponite say summon fun\n\
+            \   with orange soapstone say summon fun\n\
             \ you died \
             \ farewell ashen one"
             errors <- U.extractErrors p

--- a/test/Semantic/IterationsSpec.hs
+++ b/test/Semantic/IterationsSpec.hs
@@ -13,7 +13,7 @@ spec = describe "Iterations declarations" $ do
     \ upgrading i with 1 soul until level 10 \n\
     \ traveling somewhere \n\
     \ i <<= 1 + 1 \\ \n\
-    \ with orange saponite say @hello world@ \n\
+    \ with orange soapstone say @hello world@ \n\
     \ you died \n\
     \ max level reached \n\
     \ you died \n\
@@ -25,7 +25,7 @@ spec = describe "Iterations declarations" $ do
     \ with const i of type humanity <<= 1 in your inventory \n\
     \ upgrading i with 1 soul until level 10 \n\
     \ traveling somewhere \n\
-    \ with orange saponite say @hello world@ \n\
+    \ with orange soapstone say @hello world@ \n\
     \ you died \n\
     \ max level reached \n\
     \ you died \n\

--- a/test/Semantic/OffsetSpec.hs
+++ b/test/Semantic/OffsetSpec.hs
@@ -14,7 +14,7 @@ testOffset = testProgram . baseProgram
                     \ with \
                     \" ++ s ++ "\
                     \ in your inventory \
-                    \ with orange saponite say @hello world@ \
+                    \ with orange soapstone say @hello world@ \
                     \ you died \
                     \ farewell ashen one"
 

--- a/test/Semantic/PointersSpec.hs
+++ b/test/Semantic/PointersSpec.hs
@@ -22,7 +22,7 @@ sampleProgram instr = "hello ashen one\n\
 \   var y of type humanity\n\
 \in your inventory\n\
 \   " ++ instr ++ "\n\
-\   with orange saponite say @hello world@\n\
+\   with orange soapstone say @hello world@\n\
 \you died\n\
 
 \farewell ashen one\n"

--- a/test/Semantic/ProceduresSpec.hs
+++ b/test/Semantic/ProceduresSpec.hs
@@ -28,7 +28,7 @@ spec = do
 
 
             \ traveling somewhere \
-            \ with orange saponite say @hello world@ \
+            \ with orange soapstone say @hello world@ \
             \ you died \
             \ farewell ashen one"
             (_, ST.SymTable {ST.stDict=dict}, _) <- U.extractSymTable p
@@ -50,7 +50,7 @@ spec = do
 
 
             \ traveling somewhere \
-            \ with orange saponite say @hello world@ \
+            \ with orange soapstone say @hello world@ \
             \ you died \
             \ farewell ashen one"
             (_, ST.SymTable {ST.stDict=dict}, _) <- U.extractSymTable p
@@ -76,7 +76,7 @@ spec = do
 
 
             \ traveling somewhere \
-            \ with orange saponite say @hello world@ \
+            \ with orange soapstone say @hello world@ \
             \ you died \
             \ farewell ashen one"
             (_, ST.SymTable {ST.stDict=dict}, _) <- U.extractSymTable p
@@ -101,7 +101,7 @@ spec = do
 
 
             \ traveling somewhere \
-            \ with orange saponite say @hello world@ \
+            \ with orange soapstone say @hello world@ \
             \ you died \
             \ farewell ashen one"
             (_, ST.SymTable {ST.stDict=dict}, _) <- U.extractSymTable p
@@ -132,7 +132,7 @@ spec = do
 
 
             \ traveling somewhere \
-            \ with orange saponite say @hello world@ \
+            \ with orange soapstone say @hello world@ \
             \ you died \
             \ farewell ashen one" `U.shouldErrorOn` ("x", 5, 8)
         it "rejects to declare variables on the first scope of a procedure whose names are on the arg list" $
@@ -154,7 +154,7 @@ spec = do
 
 
             \ traveling somewhere \
-            \ with orange saponite say @hello world@ \
+            \ with orange soapstone say @hello world@ \
             \ you died \
             \ farewell ashen one" `U.shouldErrorOn` ("x", 8, 8)
         it "allows to declare more than 1 procedure" $ do
@@ -178,7 +178,7 @@ spec = do
 
 
             \ traveling somewhere \
-            \ with orange saponite say @hello world@ \
+            \ with orange soapstone say @hello world@ \
             \ you died \
             \ farewell ashen one"
             (_, ST.SymTable {ST.stDict=dict}, errors) <- U.extractSymTable p

--- a/test/Semantic/RecordLikeTypesDeclSpec.hs
+++ b/test/Semantic/RecordLikeTypesDeclSpec.hs
@@ -192,7 +192,7 @@ spec = do
 
             \you died\n\
 
-            \farewell ashen one" `U.shouldErrorOn` ("~>", 8, 31)
+            \farewell ashen one" `U.shouldErrorOn` ("~>", 8, 32)
         it "allows to access ST.record properties of arrays of records" $
             U.shouldNotError "hello ashen one\n\
 
@@ -224,7 +224,7 @@ spec = do
 
             \you died\n\
 
-            \farewell ashen one" `U.shouldErrorOn` ("~>", 6, 36)
+            \farewell ashen one" `U.shouldErrorOn` ("~>", 6, 37)
         it "accepts valid x<$0$> ~> y ~> z<$0$> ~> a" $
             U.shouldNotError "hello ashen one\n\
 
@@ -264,7 +264,7 @@ spec = do
 
             \you died\n\
 
-            \farewell ashen one" `U.shouldErrorOn` ("~>", 12, 51)
+            \farewell ashen one" `U.shouldErrorOn` ("~>", 12, 52)
         it "accepts valid assigment of a struct literal for record" $
             U.shouldNotError "hello ashen one\n\
 

--- a/test/Semantic/RecordLikeTypesDeclSpec.hs
+++ b/test/Semantic/RecordLikeTypesDeclSpec.hs
@@ -138,7 +138,7 @@ spec = do
             \   }\n\
             \in your inventory\n\
 
-            \   with orange saponite say x ~> y\n\
+            \   with orange soapstone say x ~> y\n\
 
             \you died\n\
 
@@ -156,7 +156,7 @@ spec = do
             \   }\n\
             \in your inventory\n\
 
-            \   with orange saponite say x ~> y ~> z\n\
+            \   with orange soapstone say x ~> y ~> z\n\
 
             \you died\n\
 
@@ -172,7 +172,7 @@ spec = do
             \   }\n\
             \in your inventory\n\
 
-            \   with orange saponite say x ~> x\n\
+            \   with orange soapstone say x ~> x\n\
 
             \you died\n\
 
@@ -188,7 +188,7 @@ spec = do
             \   }\n\
             \in your inventory\n\
 
-            \   with orange saponite say x ~> z\n\
+            \   with orange soapstone say x ~> z\n\
 
             \you died\n\
 
@@ -206,7 +206,7 @@ spec = do
             \   }\n\
             \in your inventory\n\
 
-            \   with orange saponite say x <$ 0 $> ~> y ~> z\n\
+            \   with orange soapstone say x <$ 0 $> ~> y ~> z\n\
 
             \you died\n\
 
@@ -220,7 +220,7 @@ spec = do
             \   var x of type <1>-chest of type humanity\n\
             \in your inventory\n\
 
-            \   with orange saponite say x<$0$> ~> z\n\
+            \   with orange soapstone say x<$0$> ~> z\n\
 
             \you died\n\
 
@@ -240,7 +240,7 @@ spec = do
             \   }\n\
             \in your inventory\n\
 
-            \   with orange saponite say x<$0$> ~> y ~> z<$0$> ~> a\n\
+            \   with orange soapstone say x<$0$> ~> y ~> z<$0$> ~> a\n\
 
             \you died\n\
 
@@ -260,7 +260,7 @@ spec = do
             \   }\n\
             \in your inventory\n\
 
-            \   with orange saponite say x<$0$> ~> y ~> z<$0$> ~> b\n\
+            \   with orange soapstone say x<$0$> ~> y ~> z<$0$> ~> b\n\
 
             \you died\n\
 

--- a/test/Semantic/SimpleTypesDeclSpec.hs
+++ b/test/Semantic/SimpleTypesDeclSpec.hs
@@ -236,7 +236,7 @@ spec = do
             \ with \
             \   var x of type humanity \
             \ in your inventory \
-            \ with orange saponite say x \
+            \ with orange soapstone say x \
             \ you died \
 
             \ farewell ashen one"
@@ -251,7 +251,7 @@ spec = do
 
             \while the lit covenant is active:\n\
             \traveling somewhere\n\
-            \   with orange saponite say x\n\
+            \   with orange soapstone say x\n\
             \you died\n\
             \covenant left\n\
             \ you died\n\
@@ -347,7 +347,7 @@ spec = do
             \ with\n\
             \   var x of type humanity\n\
             \ in your inventory\n\
-            \   with orange saponite say y\n\
+            \   with orange soapstone say y\n\
             \ you died \
 
             \ farewell ashen one" `U.shouldErrorOn` ("y", 6, 29)
@@ -361,7 +361,7 @@ spec = do
             \ with\n\
             \   var x of type small humanity <<= 1\n\
             \ in your inventory\n\
-            \   with orange saponite say @oh yes@\n\
+            \   with orange soapstone say @oh yes@\n\
             \ you died\n\
 
             \ farewell ashen one"
@@ -386,7 +386,7 @@ spec = do
             \   var x of type small humanity <<= 1,\n\
             \   var y of type small humanity <<= 22\n\
             \ in your inventory\n\
-            \   with orange saponite say @oh yes@\n\
+            \   with orange soapstone say @oh yes@\n\
             \ you died\n\
 
             \ farewell ashen one"

--- a/test/Semantic/SimpleTypesDeclSpec.hs
+++ b/test/Semantic/SimpleTypesDeclSpec.hs
@@ -350,7 +350,7 @@ spec = do
             \   with orange soapstone say y\n\
             \ you died \
 
-            \ farewell ashen one" `U.shouldErrorOn` ("y", 6, 29)
+            \ farewell ashen one" `U.shouldErrorOn` ("y", 6, 30)
 
     describe "Correctly handles initialization (declaration + assignments)" $ do
         it "Prepends assignment instruction on initialization" $ do

--- a/test/Semantic/VariablesSpec.hs
+++ b/test/Semantic/VariablesSpec.hs
@@ -28,7 +28,7 @@ testVoid prog = U.testVoid (program prog)
 spec :: Spec
 spec = describe "Constants" $ do
   it "rejects constant reassignments" $ program "b <<= 1" `U.shouldErrorOn` ("b", 9, 5)
-  it "allows to use constants on expressions" $ U.shouldNotError $ program "with orange saponite say b"
+  it "allows to use constants on expressions" $ U.shouldNotError $ program "with orange soapstone say b"
   it "rejects constant array reassignments" $ program "c<$0$> <<= 1" `U.shouldErrorOn` ("c", 9, 5)
   it "allows variable reassignments" $ U.shouldNotError $ program "a <<= 3"
   it "allows variable arrays reassignments" $ U.shouldNotError $ program "d<$0$> <<= 3"

--- a/test/Semantic/WidthSpec.hs
+++ b/test/Semantic/WidthSpec.hs
@@ -25,7 +25,7 @@ testWidth programFragment expectedWidth = do
                     \ help received \
 
                     \ traveling somewhere \
-                    \ with orange saponite say @hello world@ \
+                    \ with orange soapstone say @hello world@ \
                     \ you died \
                     \ farewell ashen one"
 
@@ -98,7 +98,7 @@ spec = do
                     \ help received \
 
                     \ traveling somewhere \
-                    \ with orange saponite say @hello world@ \
+                    \ with orange soapstone say @hello world@ \
                     \ you died \
                     \ farewell ashen one"
             (_, ST.SymTable {ST.stDict=dict}, _) <- U.extractSymTable program

--- a/test/TypeChecking/ForEachInstructionSpec.hs
+++ b/test/TypeChecking/ForEachInstructionSpec.hs
@@ -13,7 +13,7 @@ baseProgram t1 t2 = "hello ashen one\n\
 \in your inventory\n\
 \repairing i with titanite from is\n\
 \traveling somewhere\n\
-    \with orange saponite say i\n\
+    \with orange soapstone say i\n\
 \you died\n\
 \weaponry repaired\n\
 \you died\n\

--- a/test/TypeChecking/IOInstructionsSpec.hs
+++ b/test/TypeChecking/IOInstructionsSpec.hs
@@ -19,7 +19,7 @@ baseProgramRead :: String -> String
 baseProgramRead = baseProgram "transpose into"
 
 baseProgramPrint :: String -> String
-baseProgramPrint = baseProgram "with orange saponite say"
+baseProgramPrint = baseProgram "with orange soapstone say"
 
 spec :: Spec
 spec =

--- a/test/TypeChecking/IfInstructionSpec.hs
+++ b/test/TypeChecking/IfInstructionSpec.hs
@@ -14,7 +14,7 @@ spec =
                 \trust your inventory\n\
                 \   lit:\n\
                 \       traveling somewhere\n\
-                \           with orange saponite say @test@\n\
+                \           with orange soapstone say @test@\n\
                 \       you died\n\
                 \inventory closed\n\
                 \you died \
@@ -28,7 +28,7 @@ spec =
             \trust your inventory\n\
             \   1 + 1:\n\
             \       traveling somewhere\n\
-            \           with orange saponite say @test@\n\
+            \           with orange soapstone say @test@\n\
             \       you died\n\
             \inventory closed\n\
             \you died \

--- a/test/TypeChecking/LoopInstructionsSpec.hs
+++ b/test/TypeChecking/LoopInstructionsSpec.hs
@@ -16,7 +16,7 @@ spec =
 
                 \upgrading i with 1 souls until level 10\n\
                 \traveling somewhere\n\
-                    \with orange saponite say i\n\
+                    \with orange soapstone say i\n\
                 \you died\n\
                 \max level reached\n\
 
@@ -34,7 +34,7 @@ spec =
 
             \upgrading i with |a| souls until level 10\n\
             \traveling somewhere\n\
-                \with orange saponite say i\n\
+                \with orange soapstone say i\n\
             \you died\n\
             \max level reached\n\
 
@@ -51,7 +51,7 @@ spec =
 
             \upgrading i with 1 souls until level |t|\n\
             \traveling somewhere\n\
-                \with orange saponite say i\n\
+                \with orange soapstone say i\n\
             \you died\n\
             \max level reached\n\
 

--- a/test/TypeChecking/SwitchInstructionSpec.hs
+++ b/test/TypeChecking/SwitchInstructionSpec.hs
@@ -15,11 +15,11 @@ spec =
                 \enter dungeon with n:\n\
                 \   8:\n\
                 \       traveling somewhere\n\
-                \           with orange saponite say @test@\n\
+                \           with orange soapstone say @test@\n\
                 \       you died\n\
                 \   5:\n\
                 \       traveling somewhere\n\
-                \           with orange saponite say @test@\n\
+                \           with orange soapstone say @test@\n\
                 \       you died\n\
                 \dungeon exited\n\
                 \you died \
@@ -35,11 +35,11 @@ spec =
             \enter dungeon with n:\n\
             \   8:\n\
             \       traveling somewhere\n\
-            \           with orange saponite say @test@\n\
+            \           with orange soapstone say @test@\n\
             \       you died\n\
             \   |a|:\n\
             \       traveling somewhere\n\
-            \           with orange saponite say @test@\n\
+            \           with orange soapstone say @test@\n\
             \       you died\n\
             \dungeon exited\n\
             \you died \

--- a/test/TypeChecking/WhileInstructionSpec.hs
+++ b/test/TypeChecking/WhileInstructionSpec.hs
@@ -13,7 +13,7 @@ spec =
                 \traveling somewhere \n\
                 \while the lit covenant is active:\n\
                 \       traveling somewhere\n\
-                \           with orange saponite say @test@\n\
+                \           with orange soapstone say @test@\n\
                 \       you died\n\
                 \covenant left\n\
                 \you died \
@@ -26,7 +26,7 @@ spec =
             \traveling somewhere \n\
             \while the 1 covenant is active:\n\
             \       traveling somewhere\n\
-            \           with orange saponite say @test@\n\
+            \           with orange soapstone say @test@\n\
             \       you died\n\
             \covenant left\n\
             \you died \


### PR DESCRIPTION
**What is this?**

After I recently started a new run on **Dark Souls: Remastered Edition** on my Nintendo Switch, in English (as opposed to all my previous runs, which had been in Spanish), I soon came to a terrifying realization: the real name for "saponita" in English is _soapstone_, not _saponite_ which is how we had used the token ever since we started this never-ending compiler project.

In this PR, I change all the instances of _saponite_ to _soapstone_ (random fact: there _is_ a real mineral called _soapstone_ in real life) to properly follow the Dark Souls lore. That's it, that's all the changes.